### PR TITLE
Update signet.js and fakenet-signer to stable

### DIFF
--- a/contract/CLAUDE.md
+++ b/contract/CLAUDE.md
@@ -17,7 +17,11 @@ Tests are **long-running and verbose** (timeout is set to 1,000,000ms). Always r
 
 Anchor reads the RPC URL and wallet from `solana config` — no need to set `ANCHOR_PROVIDER_URL` or `ANCHOR_WALLET` env vars. Verify with `solana config get`.
 
-ETH and BTC test suites can run together. BTC tests require a local Bitcoin regtest node (see error output for setup instructions).
+ETH and BTC test suites can run together. BTC tests require a local Bitcoin regtest node:
+
+```bash
+cd ~/Documents/signet/bitcoin-regtest && pnpm docker:dev
+```
 
 ### Running all tests
 

--- a/contract/CLAUDE.md
+++ b/contract/CLAUDE.md
@@ -17,22 +17,19 @@ Tests are **long-running and verbose** (timeout is set to 1,000,000ms). Always r
 
 Anchor reads the RPC URL and wallet from `solana config` — no need to set `ANCHOR_PROVIDER_URL` or `ANCHOR_WALLET` env vars. Verify with `solana config get`.
 
-ETH and BTC test suites must be run **separately** — never run both at the same time.
+ETH and BTC test suites can run together. BTC tests require a local Bitcoin regtest node (see error output for setup instructions).
 
-Use `--skip-deploy` since the program is already deployed on devnet.
-
-### Running ETH tests
+### Running all tests
 
 ```bash
 # Run in background via Bash tool with run_in_background: true
-anchor test --skip-deploy -- --grep "ERC20"
+anchor test
 ```
 
-### Running BTC tests
+### Running without re-deploying
 
 ```bash
-# Run in background via Bash tool with run_in_background: true
-anchor test --skip-deploy -- --grep "BTC"
+anchor test --skip-deploy
 ```
 
 ### How to monitor

--- a/contract/package.json
+++ b/contract/package.json
@@ -14,9 +14,9 @@
     "dotenv": "^17.2.3",
     "ecpair": "^3.0.0",
     "ethers": "^6.14.4",
-    "fakenet-signer": "^1.7.1-beta.12",
+    "fakenet-signer": "^1.7.1",
     "pino": "^10.1.0",
-    "signet.js": "^0.3.1-beta.4",
+    "signet.js": "^0.3.1",
     "tiny-secp256k1": "^2.2.4",
     "zod": "^4.1.11"
   },

--- a/contract/yarn.lock
+++ b/contract/yarn.lock
@@ -1561,10 +1561,10 @@ eyes@^0.1.8:
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
 
-fakenet-signer@^1.7.1-beta.12:
-  version "1.7.1-beta.12"
-  resolved "https://registry.yarnpkg.com/fakenet-signer/-/fakenet-signer-1.7.1-beta.12.tgz#5675769ff541126a3430caf92a92e8b27bbea24f"
-  integrity sha512-MlT9JbSLBtTGUiHGFBHp1z0FbbrTmhvT1ukrIDT64x7B4SfUjz4tvMiMkLxg2n6ZmwacGPgGGrz8MoBZFvgoQw==
+fakenet-signer@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/fakenet-signer/-/fakenet-signer-1.7.1.tgz#7f44ba79e90664b1d3efb9f42f652d9aa11b226e"
+  integrity sha512-HaXeF6F38UqvlO5E8LxN09lqwasXae5zMS3e0xKqrx0KXIbPPQQ9gCua80xxGyC5LtRP8mTqJAq9WWI0NVpIJg==
   dependencies:
     "@coral-xyz/anchor" "^0.31.0"
     "@solana/web3.js" "^1.98.0"
@@ -1575,7 +1575,7 @@ fakenet-signer@^1.7.1-beta.12:
     dotenv "^17.2.3"
     ecpair "^2.1.0"
     ethers "^6.13.5"
-    signet.js "0.3.1-beta.1"
+    signet.js "0.3.1"
     tiny-secp256k1 "^2.2.3"
     tsx "^4.19.2"
     zod "^4.1.11"
@@ -2581,33 +2581,10 @@ sha.js@^2.4.0:
     safe-buffer "^5.2.1"
     to-buffer "^1.2.0"
 
-signet.js@0.3.1-beta.1:
-  version "0.3.1-beta.1"
-  resolved "https://registry.yarnpkg.com/signet.js/-/signet.js-0.3.1-beta.1.tgz#f8e6482ff6bd0194ee7ebd0ed3940c39807ba879"
-  integrity sha512-HvYn66VafUBV8SSK7eJEJNmm2EQeD6ZQ/O64zTx47M8O9OcOh55f6xibTQbmTNMVOiXqsw5PCCAKt0wfQ/AVLA==
-  dependencies:
-    "@coral-xyz/anchor" "^0.31.0"
-    "@cosmjs/amino" "^0.32.4"
-    "@cosmjs/crypto" "^0.32.4"
-    "@cosmjs/encoding" "^0.32.4"
-    "@cosmjs/math" "^0.32.4"
-    "@cosmjs/proto-signing" "^0.32.4"
-    "@cosmjs/stargate" "^0.32.4"
-    "@scure/base" "^1.2.4"
-    "@solana/web3.js" "^1.98.0"
-    bech32 "^2.0.0"
-    bitcoinjs-lib "^6.1.5"
-    bn.js "^5.2.1"
-    chain-registry "^1.69.72"
-    coinselect "^3.1.13"
-    cosmjs-types "^0.9.0"
-    elliptic "^6.6.1"
-    viem "^2.22.14"
-
-signet.js@^0.3.1-beta.4:
-  version "0.3.1-beta.4"
-  resolved "https://registry.yarnpkg.com/signet.js/-/signet.js-0.3.1-beta.4.tgz#8d1858ae6d88424fb8499b5463725fae7e4124c5"
-  integrity sha512-aSKPTiRxqU8x3xH2wUNYmRZwMNz5q4H7CihP0eHvPlde8uKqnVG+nCngeTezufhHg2RE8NO+2uwt+oXgODqNBg==
+signet.js@0.3.1, signet.js@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/signet.js/-/signet.js-0.3.1.tgz#cc4af0f6f4e6f47b8d9797430a0e316f3705de17"
+  integrity sha512-5LFcp9/ofvMziYMpL2aEcV+J/pwxBK6z6zdbfaQKmi31mEfr6MDryiZj3AgTO1zl12PjeBJ0C37KTtoz9bZMcQ==
   dependencies:
     "@coral-xyz/anchor" "^0.31.0"
     "@cosmjs/amino" "^0.32.4"

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -51,7 +51,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot='dialog-content'
         className={cn(
-          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] border-dark-neutral-50 fixed top-1/2 left-1/2 z-50 grid w-[calc(100vw-2rem)] max-w-md translate-x-[-50%] translate-y-[-50%] gap-5 rounded-sm border bg-white p-6 shadow-xl duration-200 sm:w-full sm:p-8',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] border-dark-neutral-50 fixed top-1/2 left-1/2 z-50 grid w-[calc(100vw-2rem)] max-w-md max-h-[calc(100vh-2rem)] translate-x-[-50%] translate-y-[-50%] gap-5 overflow-y-auto rounded-sm border bg-white p-6 shadow-xl duration-200 sm:w-full sm:p-8',
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary
- Update `signet.js` from `^0.3.1-beta.4` to `^0.3.1`
- Update `fakenet-signer` from `^1.7.1-beta.12` to `^1.7.1`
- Update CLAUDE.md test instructions

## Test plan
- [x] All 15 tests passing (ERC20 + BTC)