### PR TITLE
feat(midnight): swap widget

### DIFF
--- a/frontend/.vercelignore
+++ b/frontend/.vercelignore
@@ -1,0 +1,6 @@
+# The ZK assets (vault + signet prover keys) are 100-280 MB per file — over Vercel's 100 MB file
+# cap — so they're hosted on object storage and fetched via NEXT_PUBLIC_ZK_CONFIG_ORIGIN.
+public/keys
+public/zkir
+public/compiler
+public/signet

--- a/frontend/app/api/midnight/gas-topup/route.ts
+++ b/frontend/app/api/midnight/gas-topup/route.ts
@@ -22,7 +22,7 @@ const TOPUP_MAX_FEE_WITH_MARGIN = (ERC20_TRANSFER_MAX_FEE_PER_GAS * 110n) / 100n
 // bridge's automatic gas top-up. The Midnight-chain txs (deposit/claim) stay client-side.
 export async function POST(request: NextRequest) {
   try {
-    const { fromAddress } = await request.json();
+    const { fromAddress, gasLimit } = await request.json();
 
     if (!fromAddress) {
       return NextResponse.json(
@@ -31,13 +31,17 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // A transfer/approve reserves the fixed envelope; a swap needs more (a V3 swap is
+    // ~300k), so the caller may request a larger gasLimit. Defaults to the transfer envelope.
+    const limit = gasLimit ? BigInt(gasLimit) : ERC20_TRANSFER_GAS_LIMIT;
+
     const client = getEthereumProvider();
     // Fund fromAddress so its balance >= gasLimit * maxFeePerGas (the vault tx's upfront
     // EIP-1559 reservation), with a 10% margin.
     const { topUpTxHash, topUpAmount } = await ensureGasForTransaction(
       client,
       fromAddress as Hex,
-      ERC20_TRANSFER_GAS_LIMIT,
+      limit,
       TOPUP_MAX_FEE_WITH_MARGIN,
     );
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -21,8 +21,8 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'Solana Token Manager',
-  description: 'Manage your ERC20 tokens on Solana',
+  title: 'Token Manager',
+  description: 'Manage your ERC20 tokens on-chain',
 };
 
 export default function RootLayout({

--- a/frontend/components/activity-list-table/index.tsx
+++ b/frontend/components/activity-list-table/index.tsx
@@ -16,6 +16,8 @@ import {
 } from '@/components/ui/table';
 import { TruncatedText } from '@/components/ui/truncated-text';
 import { useSolanaTransactions } from '@/hooks/use-solana-transactions';
+import { useMidnightTransactions } from '@/hooks/use-midnight-transactions';
+import { useMidnightWallet } from '@/providers/midnight-context';
 import type { TxEntry, TxStatus } from '@/lib/relayer/tx-registry';
 
 import { CryptoIcon } from '../balance-display/crypto-icon';
@@ -284,6 +286,7 @@ function buildSolanaTransactions(
 
 export function ActivityListTable({ className }: ActivityListTableProps) {
   const { isConnected, account } = useWallet();
+  const midnight = useMidnightWallet();
   const [selectedTransaction, setSelectedTransaction] =
     useState<ActivityTransaction | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -299,8 +302,9 @@ export function ActivityListTable({ className }: ActivityListTableProps) {
 
   const redisTxs = buildTransactionsFromRedis(txList ?? []);
   const solanaTxsFormatted = buildSolanaTransactions(solanaTxs, account);
+  const midnightTxs = useMidnightTransactions();
 
-  const allTransactions = [...redisTxs, ...solanaTxsFormatted]
+  const allTransactions = [...redisTxs, ...solanaTxsFormatted, ...midnightTxs]
     .filter((tx, index, self) => self.findIndex(t => t.id === tx.id) === index)
     .sort((a, b) => {
       const aTime = a.timestampRaw || 0;
@@ -405,8 +409,8 @@ export function ActivityListTable({ className }: ActivityListTableProps) {
           ) : (
             <TableRow>
               <TableCell colSpan={5} className='py-8 text-center text-gray-500'>
-                {isConnected
-                  ? 'No transactions found. Send ERC20 tokens to your deposit address to see activity.'
+                {isConnected || midnight.connected
+                  ? 'No transactions found. Deposit, withdraw, or swap to see activity.'
                   : 'Connect your wallet to view transaction activity.'}
               </TableCell>
             </TableRow>

--- a/frontend/components/activity-list-table/transaction-details-dialog.tsx
+++ b/frontend/components/activity-list-table/transaction-details-dialog.tsx
@@ -45,8 +45,8 @@ const DEPOSIT_STEPS: StepConfig[] = [
   },
   {
     status: 'solana_pending',
-    label: 'Processing on Solana',
-    description: 'Creating deposit record on Solana',
+    label: 'Processing on-chain',
+    description: 'Creating deposit record on-chain',
   },
   {
     status: 'signature_pending',
@@ -94,7 +94,7 @@ const WITHDRAWAL_STEPS: StepConfig[] = [
   {
     status: 'completing',
     label: 'Finalizing',
-    description: 'Completing the withdrawal on Solana',
+    description: 'Completing the withdrawal on-chain',
   },
   {
     status: 'completed',
@@ -277,7 +277,7 @@ export function TransactionDetailsDialog({
             {/* Step 2: Solana Init (deposit or withdrawal initiation) */}
             <div className='flex items-center justify-between text-sm'>
               <span className='text-gray-500'>
-                {txStatus?.gasTopUpTxHash ? '2' : '1'}. Solana {isDeposit ? 'Init Deposit' : 'Init Withdraw'}
+                {txStatus?.gasTopUpTxHash ? '2' : '1'}. On-chain {isDeposit ? 'Init Deposit' : 'Init Withdraw'}
               </span>
               {txStatus?.solanaInitTxHash ? (
                 <a
@@ -317,7 +317,7 @@ export function TransactionDetailsDialog({
             {/* Step 4: Solana Finalize (claim or complete withdrawal) */}
             <div className='flex items-center justify-between text-sm'>
               <span className='text-gray-500'>
-                {txStatus?.gasTopUpTxHash ? '4' : '3'}. Solana {isDeposit ? 'Claim' : 'Finalize'}
+                {txStatus?.gasTopUpTxHash ? '4' : '3'}. On-chain {isDeposit ? 'Claim' : 'Finalize'}
               </span>
               {txStatus?.solanaFinalizeTxHash ? (
                 <a

--- a/frontend/components/empty-state-wallet.tsx
+++ b/frontend/components/empty-state-wallet.tsx
@@ -7,8 +7,8 @@ export function EmptyStateWallet() {
   return (
     <EmptyState
       icon={Wallet}
-      title='Ethereum Assets in Solana Contracts'
-      description='Deposit ERC-20 tokens and your Solana program can call into Ethereum liquidity, markets, and assets'
+      title='Ethereum Assets in an ERC-20 Vault'
+      description='Deposit ERC-20 tokens and your program can call into Ethereum liquidity, markets, and assets'
       action={
         <>
           <div className='mb-12 flex justify-center'>

--- a/frontend/components/midnight-progress-toaster.tsx
+++ b/frontend/components/midnight-progress-toaster.tsx
@@ -14,7 +14,12 @@ export function MidnightProgressToaster() {
 
   useEffect(() => {
     const onState = (s: FlowState) => {
-      const kind = s.kind === 'withdraw' ? 'Withdrawal' : 'Deposit';
+      const kind =
+        s.kind === 'withdraw'
+          ? 'Withdrawal'
+          : s.kind === 'swap'
+            ? 'Swap'
+            : 'Deposit';
 
       if (s.error) {
         prevPhase.current = null;
@@ -27,10 +32,18 @@ export function MidnightProgressToaster() {
       }
       if (s.phase === 'done') {
         prevPhase.current = null;
+        if (s.refunded) {
+          toast.warning(`${kind} didn't execute on-chain — tokens refunded`, {
+            id: TOAST_ID,
+          });
+          return;
+        }
         toast.success(
           s.kind === 'withdraw'
             ? 'Withdrawal complete'
-            : 'Deposit complete — shielded token minted',
+            : s.kind === 'swap'
+              ? 'Swap complete — shielded token minted'
+              : 'Deposit complete — shielded token minted',
           { id: TOAST_ID },
         );
         return;

--- a/frontend/components/swap-widget/index.tsx
+++ b/frontend/components/swap-widget/index.tsx
@@ -14,7 +14,7 @@ import { midnightEnv } from '@/lib/midnight/env';
 import {
   discoverSwappablePairs,
   pairKey,
-  quoteBestFee,
+  quoteBestFeeExactInput,
 } from '@/lib/midnight/evm-swap';
 import type { Token } from '@/lib/types/token.types';
 
@@ -31,8 +31,9 @@ interface SwapWidgetProps {
   className?: string;
 }
 
-// Slippage presets in bps (0.1% / 0.5% / 1%). exactOutput: the swap binds amountInMaximum =
-// quote * (1 + bps), the most input it will spend for the exact output.
+// Slippage presets in bps (0.1% / 0.5% / 1%). The UI is a normal spend-in swap; on-chain it is
+// exactOutput, so slippage sets the guaranteed receive: amountOut = quotedOut * (1 - bps), bought
+// for up to the spend (amountInMaximum), with any unspent input refunded as change.
 const SLIPPAGE_PRESETS = [10n, 50n, 100n];
 const DEFAULT_SLIPPAGE_BPS = 100n;
 
@@ -54,8 +55,6 @@ export function SwapWidget({ className }: SwapWidgetProps) {
   const [swapping, setSwapping] = useState(false);
   // The Uniswap V3 fee tier discovered for the current pair (null = no pool at any tier).
   const [fee, setFee] = useState<bigint | null>(null);
-  // The amountInMaximum the swap will burn for the requested output (with slippage headroom).
-  const [maxIn, setMaxIn] = useState<bigint>(0n);
   const [quoting, setQuoting] = useState(false);
   const [slippageBps, setSlippageBps] = useState<bigint>(DEFAULT_SLIPPAGE_BPS);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -156,55 +155,51 @@ export function SwapWidget({ className }: SwapWidgetProps) {
   const toSel =
     toToken && tokens.find(t => t.erc20Address === toToken.erc20Address);
 
-  // exactOutput: the user enters the DESIRED OUTPUT (toAmount); we quote the required INPUT
-  // across fee tiers (discovering the tier that actually has a pool — USDC/EURC is 0.05% but
-  // USDC/DAI may only exist at another tier) and show the amountInMaximum the swap burns in the
-  // from field. Best-effort; the swap re-quotes on-chain. Debounced, cancelled if inputs change.
+  // Normal swap UX: the user enters the SPEND (fromAmount); we quote across fee tiers (discovering
+  // the tier that actually has a pool — USDC/EURC is 0.05% but USDC/DAI may only exist at another
+  // tier) to show the expected receive in the to field. On-chain the swap is exactOutput; the min
+  // received is derived from slippage in runSwap. Best-effort estimate. Debounced, cancelled on change.
   useEffect(() => {
     setFee(null);
-    setMaxIn(0n);
     if (
       !enabled ||
       !fromSel ||
       !toSel ||
       fromSel.erc20Address === toSel.erc20Address
     ) {
-      setFromAmount('');
+      setToAmount('');
       return;
     }
-    let amountOut: bigint;
+    let amountIn: bigint;
     try {
-      amountOut = parseUnits(toAmount || '0', toSel.decimals);
+      amountIn = parseUnits(fromAmount || '0', fromSel.decimals);
     } catch {
-      setFromAmount('');
+      setToAmount('');
       return;
     }
-    if (amountOut <= 0n) {
-      setFromAmount('');
+    if (amountIn <= 0n) {
+      setToAmount('');
       return;
     }
     let cancelled = false;
     setQuoting(true);
     const id = setTimeout(async () => {
       try {
-        const best = await quoteBestFee(
+        const best = await quoteBestFeeExactInput(
           midnightEnv.evmRpcUrl,
           fromSel.erc20Address,
           toSel.erc20Address,
-          amountOut,
-          slippageBps,
+          amountIn,
         );
         if (cancelled) return;
         setFee(best?.fee ?? null);
-        setMaxIn(best?.amountInMaximum ?? 0n);
-        setFromAmount(
-          best ? formatUnits(best.amountInMaximum, fromSel.decimals) : '',
+        setToAmount(
+          best ? formatUnits(best.amountOut, toSel.decimals) : '',
         );
       } catch {
         if (!cancelled) {
           setFee(null);
-          setMaxIn(0n);
-          setFromAmount('');
+          setToAmount('');
         }
       } finally {
         if (!cancelled) setQuoting(false);
@@ -214,25 +209,25 @@ export function SwapWidget({ className }: SwapWidgetProps) {
       cancelled = true;
       clearTimeout(id);
     };
-  }, [enabled, toAmount, fromSel, toSel, slippageBps]);
+  }, [enabled, fromAmount, fromSel, toSel]);
 
-  // The user must hold at least amountInMaximum of tokenIn (the swap burns it up front).
+  // The user spends fromAmount of tokenIn (the swap burns it up front), so they must hold it.
   const amountValid = (() => {
     if (!fromSel || !toSel) return false;
     try {
-      const out = parseUnits(toAmount || '0', toSel.decimals);
-      return out > 0n && maxIn > 0n && maxIn <= fromSel.units;
+      const spend = parseUnits(fromAmount || '0', fromSel.decimals);
+      return spend > 0n && spend <= fromSel.units;
     } catch {
       return false;
     }
   })();
 
-  // Whether a positive output has been entered (for the "no pool" hint, which fires when a valid
-  // output yields no tier — amountValid requires a successful quote so can't express it).
-  const outEntered = (() => {
-    if (!toSel) return false;
+  // Whether a positive spend has been entered (for the "no pool" hint, which fires when a valid
+  // spend yields no tier — amountValid requires a successful quote so can't express it).
+  const inEntered = (() => {
+    if (!fromSel) return false;
     try {
-      return parseUnits(toAmount || '0', toSel.decimals) > 0n;
+      return parseUnits(fromAmount || '0', fromSel.decimals) > 0n;
     } catch {
       return false;
     }
@@ -250,13 +245,13 @@ export function SwapWidget({ className }: SwapWidgetProps) {
 
   const handleSwap = () => {
     if (!canSwap || !fromSel || !toSel || fee === null) return;
-    const amountOut = parseUnits(toAmount, toSel.decimals);
+    const amountIn = parseUnits(fromAmount, fromSel.decimals);
     setSwapping(true);
     midnight
       .swap(
         fromSel.erc20Address,
         toSel.erc20Address,
-        amountOut,
+        amountIn,
         fee,
         slippageBps,
       )
@@ -270,7 +265,7 @@ export function SwapWidget({ className }: SwapWidgetProps) {
       .finally(() => setSwapping(false));
   };
 
-  const noPool = outEntered && !quoting && fee === null;
+  const noPool = inEntered && !quoting && fee === null;
   const buttonLabel = !enabled
     ? 'Connect Midnight to swap'
     : swappablePairs === null
@@ -308,9 +303,9 @@ export function SwapWidget({ className }: SwapWidgetProps) {
           <DialogHeader>
             <DialogTitle>Swap settings</DialogTitle>
             <DialogDescription>
-              Max slippage — you receive the exact output; the swap reverts
-              on-chain if the required input exceeds this tolerance above the
-              quote.
+              Max slippage — sets the minimum you receive for your spend. The
+              swap reverts on-chain if the output would fall more than this
+              below the quote.
             </DialogDescription>
           </DialogHeader>
           <div className='flex flex-wrap gap-2'>
@@ -331,12 +326,12 @@ export function SwapWidget({ className }: SwapWidgetProps) {
       <div className='flex flex-col gap-4'>
         <TokenAmountDisplay
           value={fromAmount}
-          onChange={() => {}}
+          onChange={setFromAmount}
           tokens={enabled ? fromTokens : []}
           selectedToken={fromSel}
           onTokenSelect={t => setFromToken(t as TokenWithBalance)}
           placeholder='0'
-          disabled={!enabled}
+          disabled={!enabled || progress.active}
         />
 
         <div className='flex justify-center'>
@@ -345,12 +340,13 @@ export function SwapWidget({ className }: SwapWidgetProps) {
 
         <TokenAmountDisplay
           value={toAmount}
-          onChange={setToAmount}
+          onChange={() => {}}
           tokens={enabled ? toTokens : []}
           selectedToken={toSel}
           onTokenSelect={t => setToToken(t as TokenWithBalance)}
           placeholder='0'
           disabled={!enabled}
+          readOnly
         />
       </div>
 

--- a/frontend/components/swap-widget/index.tsx
+++ b/frontend/components/swap-widget/index.tsx
@@ -1,29 +1,236 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ArrowDown, Settings2 } from 'lucide-react';
+import { formatUnits, parseUnits } from 'viem';
+import { toast } from 'sonner';
 
 import { cn } from '@/lib/utils';
 import { TokenAmountDisplay } from '@/components/ui/token-amount-display';
+import { MIDNIGHT_TOKENS } from '@/lib/constants/token-metadata';
+import { useMidnightWallet } from '@/providers/midnight-context';
+import { useMidnightProgress } from '@/hooks/use-midnight-progress';
+import { midnightEnv } from '@/lib/midnight/env';
+import { discoverSwappablePairs, pairKey, quoteBestFee } from '@/lib/midnight/evm-swap';
 import type { Token } from '@/lib/types/token.types';
 
 import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
 
 interface SwapWidgetProps {
   className?: string;
 }
 
-type TokenWithBalance = Token & { balance: string };
+// Slippage presets in bps (0.1% / 0.5% / 1%). The swap binds amountOutMin = quote * (1 - bps).
+const SLIPPAGE_PRESETS = [10n, 50n, 100n];
+const DEFAULT_SLIPPAGE_BPS = 100n;
 
-// Swap is disabled - tokens will be loaded when feature is enabled
+type TokenWithBalance = Token & { balance: string; units: bigint };
+
+// Swap uses the shielded vault-token balance (vaultUnits) as the spendable source, and
+// mints the swapped-to token back as a shielded coin. Midnight-only: the UI stays disabled
+// until the Midnight (Developer) wallet is connected, then draws from MIDNIGHT_TOKENS.
 export function SwapWidget({ className }: SwapWidgetProps) {
+  const midnight = useMidnightWallet();
+  const progress = useMidnightProgress();
+
   const [fromAmount, setFromAmount] = useState('');
   const [toAmount, setToAmount] = useState('');
   const [fromToken, setFromToken] = useState<TokenWithBalance | undefined>();
   const [toToken, setToToken] = useState<TokenWithBalance | undefined>();
+  // Local: whether THIS widget kicked off a swap. progress.active is the shared flow state
+  // (deposit/withdraw/swap all use one flow), so it can't distinguish a swap from a deposit.
+  const [swapping, setSwapping] = useState(false);
+  // The Uniswap V3 fee tier discovered for the current pair (null = no pool at any tier).
+  const [fee, setFee] = useState<bigint | null>(null);
+  const [quoting, setQuoting] = useState(false);
+  const [slippageBps, setSlippageBps] = useState<bigint>(DEFAULT_SLIPPAGE_BPS);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  // Which token pairs have a Uniswap pool (pairKey set; null while still discovering). Only
+  // tokens that pair with something are offered — a token with no pool anywhere is hidden.
+  const [swappablePairs, setSwappablePairs] = useState<Set<string> | null>(null);
 
-  // No tokens available until swap is enabled and decimals are fetched from chain
-  const supportedTokens: TokenWithBalance[] = [];
+  const enabled = midnight.connected;
+
+  // One entry per Midnight token: shielded vault balance (spendable) + on-chain decimals.
+  const tokens: TokenWithBalance[] = useMemo(() => {
+    const perToken = midnight.balances?.perToken;
+    return MIDNIGHT_TOKENS.map(t => {
+      const b = perToken?.[t.erc20Address.toLowerCase()];
+      const decimals = b?.decimals ?? 6;
+      const units = b?.vaultUnits ?? 0n;
+      return {
+        erc20Address: t.erc20Address,
+        symbol: t.symbol,
+        name: t.name,
+        decimals,
+        chain: 'midnight' as const,
+        units,
+        balance: formatUnits(units, decimals),
+      };
+    });
+  }, [midnight.balances]);
+
+  // Discover which pairs actually have a pool (once, on connect). Token addresses are static,
+  // so this doesn't depend on balances.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    discoverSwappablePairs(midnightEnv.evmRpcUrl, MIDNIGHT_TOKENS.map(t => t.erc20Address))
+      .then(pairs => !cancelled && setSwappablePairs(pairs))
+      .catch(() => !cancelled && setSwappablePairs(new Set()));
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  // From = any token with a pool to something; To = tokens that pair with the current From.
+  const fromTokens = useMemo(
+    () =>
+      swappablePairs
+        ? tokens.filter(t =>
+            tokens.some(
+              o => o.erc20Address !== t.erc20Address && swappablePairs.has(pairKey(t.erc20Address, o.erc20Address)),
+            ),
+          )
+        : [],
+    [tokens, swappablePairs],
+  );
+  const toTokens = useMemo(
+    () =>
+      swappablePairs && fromToken
+        ? tokens.filter(
+            t =>
+              t.erc20Address !== fromToken.erc20Address &&
+              swappablePairs.has(pairKey(fromToken.erc20Address, t.erc20Address)),
+          )
+        : [],
+    [tokens, swappablePairs, fromToken],
+  );
+
+  // Default the from/to selections to a valid swappable pair, preferring a From the user holds.
+  useEffect(() => {
+    if (!enabled || fromTokens.length === 0) return;
+    setFromToken(prev =>
+      prev && fromTokens.some(t => t.erc20Address === prev.erc20Address)
+        ? prev
+        : (fromTokens.find(t => t.units > 0n) ?? fromTokens[0]),
+    );
+  }, [enabled, fromTokens]);
+
+  // Keep To a valid partner of the current From.
+  useEffect(() => {
+    if (toTokens.length === 0) return;
+    setToToken(prev =>
+      prev && toTokens.some(t => t.erc20Address === prev.erc20Address) ? prev : toTokens[0],
+    );
+  }, [toTokens]);
+
+  // Keep the from/to selections in sync with refreshed balances (same token id, new balance).
+  const fromSel = fromToken && tokens.find(t => t.erc20Address === fromToken.erc20Address);
+  const toSel = toToken && tokens.find(t => t.erc20Address === toToken.erc20Address);
+
+  // Live quote for the "to" amount, discovering the fee tier that actually has a pool for this
+  // pair (USDC/EURC is 0.05% but USDC/DAI may only exist at another tier). Best-effort; the
+  // swap re-quotes on-chain for the slippage floor. Debounced, cancelled if inputs change.
+  useEffect(() => {
+    setFee(null);
+    if (!enabled || !fromSel || !toSel || fromSel.erc20Address === toSel.erc20Address) {
+      setToAmount('');
+      return;
+    }
+    let amountIn: bigint;
+    try {
+      amountIn = parseUnits(fromAmount || '0', fromSel.decimals);
+    } catch {
+      setToAmount('');
+      return;
+    }
+    if (amountIn <= 0n) {
+      setToAmount('');
+      return;
+    }
+    let cancelled = false;
+    setQuoting(true);
+    const id = setTimeout(async () => {
+      try {
+        const best = await quoteBestFee(
+          midnightEnv.evmRpcUrl,
+          fromSel.erc20Address,
+          toSel.erc20Address,
+          amountIn,
+          slippageBps,
+        );
+        if (cancelled) return;
+        setFee(best?.fee ?? null);
+        setToAmount(best ? formatUnits(best.amountOut, toSel.decimals) : '');
+      } catch {
+        if (!cancelled) {
+          setFee(null);
+          setToAmount('');
+        }
+      } finally {
+        if (!cancelled) setQuoting(false);
+      }
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearTimeout(id);
+    };
+  }, [enabled, fromAmount, fromSel, toSel, slippageBps]);
+
+  const amountValid = (() => {
+    if (!fromSel) return false;
+    try {
+      const units = parseUnits(fromAmount || '0', fromSel.decimals);
+      return units > 0n && units <= fromSel.units;
+    } catch {
+      return false;
+    }
+  })();
+
+  const canSwap =
+    enabled &&
+    !!fromSel &&
+    !!toSel &&
+    fromSel.erc20Address !== toSel.erc20Address &&
+    amountValid &&
+    fee !== null &&
+    !quoting &&
+    !progress.active;
+
+  const handleSwap = () => {
+    if (!canSwap || !fromSel || !toSel || fee === null) return;
+    const units = parseUnits(fromAmount, fromSel.decimals);
+    setSwapping(true);
+    midnight
+      .swap(fromSel.erc20Address, toSel.erc20Address, units, fee, slippageBps)
+      .then(() => {
+        setFromAmount('');
+        setToAmount('');
+      })
+      .catch((e: unknown) => toast.error(e instanceof Error ? e.message : 'Swap failed'))
+      .finally(() => setSwapping(false));
+  };
+
+  const noPool = amountValid && !quoting && fee === null;
+  const buttonLabel = !enabled
+    ? 'Connect Midnight to swap'
+    : swappablePairs === null
+      ? 'Loading pools…'
+      : swapping
+        ? 'Swapping…'
+        : quoting
+          ? 'Fetching quote…'
+          : noPool
+            ? 'No pool for this pair'
+            : 'Swap';
 
   return (
     <div
@@ -38,21 +245,46 @@ export function SwapWidget({ className }: SwapWidgetProps) {
           variant='ghost'
           size='icon'
           className='h-8 w-8 p-0'
-          onClick={() => {}}
+          onClick={() => setSettingsOpen(true)}
+          aria-label='Swap settings'
         >
           <Settings2 className='text-dark-neutral-300 h-6 w-6' />
         </Button>
       </div>
 
+      <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Swap settings</DialogTitle>
+            <DialogDescription>
+              Max slippage — the swap reverts on-chain if the output falls below this
+              tolerance of the quote.
+            </DialogDescription>
+          </DialogHeader>
+          <div className='flex flex-wrap gap-2'>
+            {SLIPPAGE_PRESETS.map(bps => (
+              <Button
+                key={String(bps)}
+                variant={slippageBps === bps ? 'secondary' : 'outline'}
+                size='sm'
+                onClick={() => setSlippageBps(bps)}
+              >
+                {formatUnits(bps, 2)}%
+              </Button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+
       <div className='flex flex-col gap-4'>
         <TokenAmountDisplay
           value={fromAmount}
           onChange={setFromAmount}
-          tokens={supportedTokens}
-          selectedToken={fromToken}
-          onTokenSelect={setFromToken}
+          tokens={enabled ? fromTokens : []}
+          selectedToken={fromSel}
+          onTokenSelect={t => setFromToken(t as TokenWithBalance)}
           placeholder='0'
-          disabled={true}
+          disabled={!enabled}
         />
 
         <div className='flex justify-center'>
@@ -61,17 +293,23 @@ export function SwapWidget({ className }: SwapWidgetProps) {
 
         <TokenAmountDisplay
           value={toAmount}
-          onChange={setToAmount}
-          tokens={supportedTokens}
-          selectedToken={toToken}
-          onTokenSelect={setToToken}
+          onChange={() => {}}
+          tokens={enabled ? toTokens : []}
+          selectedToken={toSel}
+          onTokenSelect={t => setToToken(t as TokenWithBalance)}
           placeholder='0'
-          disabled={true}
+          disabled={!enabled}
         />
       </div>
 
-      <Button onClick={() => {}} disabled variant='secondary' size='lg' className='w-full'>
-        Swap
+      <Button
+        onClick={handleSwap}
+        disabled={!canSwap}
+        variant='secondary'
+        size='lg'
+        className='w-full'
+      >
+        {buttonLabel}
       </Button>
     </div>
   );

--- a/frontend/components/swap-widget/index.tsx
+++ b/frontend/components/swap-widget/index.tsx
@@ -11,7 +11,11 @@ import { MIDNIGHT_TOKENS } from '@/lib/constants/token-metadata';
 import { useMidnightWallet } from '@/providers/midnight-context';
 import { useMidnightProgress } from '@/hooks/use-midnight-progress';
 import { midnightEnv } from '@/lib/midnight/env';
-import { discoverSwappablePairs, pairKey, quoteBestFee } from '@/lib/midnight/evm-swap';
+import {
+  discoverSwappablePairs,
+  pairKey,
+  quoteBestFee,
+} from '@/lib/midnight/evm-swap';
 import type { Token } from '@/lib/types/token.types';
 
 import { Button } from '../ui/button';
@@ -27,7 +31,8 @@ interface SwapWidgetProps {
   className?: string;
 }
 
-// Slippage presets in bps (0.1% / 0.5% / 1%). The swap binds amountOutMin = quote * (1 - bps).
+// Slippage presets in bps (0.1% / 0.5% / 1%). exactOutput: the swap binds amountInMaximum =
+// quote * (1 + bps), the most input it will spend for the exact output.
 const SLIPPAGE_PRESETS = [10n, 50n, 100n];
 const DEFAULT_SLIPPAGE_BPS = 100n;
 
@@ -49,12 +54,16 @@ export function SwapWidget({ className }: SwapWidgetProps) {
   const [swapping, setSwapping] = useState(false);
   // The Uniswap V3 fee tier discovered for the current pair (null = no pool at any tier).
   const [fee, setFee] = useState<bigint | null>(null);
+  // The amountInMaximum the swap will burn for the requested output (with slippage headroom).
+  const [maxIn, setMaxIn] = useState<bigint>(0n);
   const [quoting, setQuoting] = useState(false);
   const [slippageBps, setSlippageBps] = useState<bigint>(DEFAULT_SLIPPAGE_BPS);
   const [settingsOpen, setSettingsOpen] = useState(false);
   // Which token pairs have a Uniswap pool (pairKey set; null while still discovering). Only
   // tokens that pair with something are offered — a token with no pool anywhere is hidden.
-  const [swappablePairs, setSwappablePairs] = useState<Set<string> | null>(null);
+  const [swappablePairs, setSwappablePairs] = useState<Set<string> | null>(
+    null,
+  );
 
   const enabled = midnight.connected;
 
@@ -82,7 +91,10 @@ export function SwapWidget({ className }: SwapWidgetProps) {
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
-    discoverSwappablePairs(midnightEnv.evmRpcUrl, MIDNIGHT_TOKENS.map(t => t.erc20Address))
+    discoverSwappablePairs(
+      midnightEnv.evmRpcUrl,
+      MIDNIGHT_TOKENS.map(t => t.erc20Address),
+    )
       .then(pairs => !cancelled && setSwappablePairs(pairs))
       .catch(() => !cancelled && setSwappablePairs(new Set()));
     return () => {
@@ -96,7 +108,9 @@ export function SwapWidget({ className }: SwapWidgetProps) {
       swappablePairs
         ? tokens.filter(t =>
             tokens.some(
-              o => o.erc20Address !== t.erc20Address && swappablePairs.has(pairKey(t.erc20Address, o.erc20Address)),
+              o =>
+                o.erc20Address !== t.erc20Address &&
+                swappablePairs.has(pairKey(t.erc20Address, o.erc20Address)),
             ),
           )
         : [],
@@ -108,7 +122,9 @@ export function SwapWidget({ className }: SwapWidgetProps) {
         ? tokens.filter(
             t =>
               t.erc20Address !== fromToken.erc20Address &&
-              swappablePairs.has(pairKey(fromToken.erc20Address, t.erc20Address)),
+              swappablePairs.has(
+                pairKey(fromToken.erc20Address, t.erc20Address),
+              ),
           )
         : [],
     [tokens, swappablePairs, fromToken],
@@ -128,32 +144,43 @@ export function SwapWidget({ className }: SwapWidgetProps) {
   useEffect(() => {
     if (toTokens.length === 0) return;
     setToToken(prev =>
-      prev && toTokens.some(t => t.erc20Address === prev.erc20Address) ? prev : toTokens[0],
+      prev && toTokens.some(t => t.erc20Address === prev.erc20Address)
+        ? prev
+        : toTokens[0],
     );
   }, [toTokens]);
 
   // Keep the from/to selections in sync with refreshed balances (same token id, new balance).
-  const fromSel = fromToken && tokens.find(t => t.erc20Address === fromToken.erc20Address);
-  const toSel = toToken && tokens.find(t => t.erc20Address === toToken.erc20Address);
+  const fromSel =
+    fromToken && tokens.find(t => t.erc20Address === fromToken.erc20Address);
+  const toSel =
+    toToken && tokens.find(t => t.erc20Address === toToken.erc20Address);
 
-  // Live quote for the "to" amount, discovering the fee tier that actually has a pool for this
-  // pair (USDC/EURC is 0.05% but USDC/DAI may only exist at another tier). Best-effort; the
-  // swap re-quotes on-chain for the slippage floor. Debounced, cancelled if inputs change.
+  // exactOutput: the user enters the DESIRED OUTPUT (toAmount); we quote the required INPUT
+  // across fee tiers (discovering the tier that actually has a pool — USDC/EURC is 0.05% but
+  // USDC/DAI may only exist at another tier) and show the amountInMaximum the swap burns in the
+  // from field. Best-effort; the swap re-quotes on-chain. Debounced, cancelled if inputs change.
   useEffect(() => {
     setFee(null);
-    if (!enabled || !fromSel || !toSel || fromSel.erc20Address === toSel.erc20Address) {
-      setToAmount('');
+    setMaxIn(0n);
+    if (
+      !enabled ||
+      !fromSel ||
+      !toSel ||
+      fromSel.erc20Address === toSel.erc20Address
+    ) {
+      setFromAmount('');
       return;
     }
-    let amountIn: bigint;
+    let amountOut: bigint;
     try {
-      amountIn = parseUnits(fromAmount || '0', fromSel.decimals);
+      amountOut = parseUnits(toAmount || '0', toSel.decimals);
     } catch {
-      setToAmount('');
+      setFromAmount('');
       return;
     }
-    if (amountIn <= 0n) {
-      setToAmount('');
+    if (amountOut <= 0n) {
+      setFromAmount('');
       return;
     }
     let cancelled = false;
@@ -164,16 +191,20 @@ export function SwapWidget({ className }: SwapWidgetProps) {
           midnightEnv.evmRpcUrl,
           fromSel.erc20Address,
           toSel.erc20Address,
-          amountIn,
+          amountOut,
           slippageBps,
         );
         if (cancelled) return;
         setFee(best?.fee ?? null);
-        setToAmount(best ? formatUnits(best.amountOut, toSel.decimals) : '');
+        setMaxIn(best?.amountInMaximum ?? 0n);
+        setFromAmount(
+          best ? formatUnits(best.amountInMaximum, fromSel.decimals) : '',
+        );
       } catch {
         if (!cancelled) {
           setFee(null);
-          setToAmount('');
+          setMaxIn(0n);
+          setFromAmount('');
         }
       } finally {
         if (!cancelled) setQuoting(false);
@@ -183,13 +214,25 @@ export function SwapWidget({ className }: SwapWidgetProps) {
       cancelled = true;
       clearTimeout(id);
     };
-  }, [enabled, fromAmount, fromSel, toSel, slippageBps]);
+  }, [enabled, toAmount, fromSel, toSel, slippageBps]);
 
+  // The user must hold at least amountInMaximum of tokenIn (the swap burns it up front).
   const amountValid = (() => {
-    if (!fromSel) return false;
+    if (!fromSel || !toSel) return false;
     try {
-      const units = parseUnits(fromAmount || '0', fromSel.decimals);
-      return units > 0n && units <= fromSel.units;
+      const out = parseUnits(toAmount || '0', toSel.decimals);
+      return out > 0n && maxIn > 0n && maxIn <= fromSel.units;
+    } catch {
+      return false;
+    }
+  })();
+
+  // Whether a positive output has been entered (for the "no pool" hint, which fires when a valid
+  // output yields no tier — amountValid requires a successful quote so can't express it).
+  const outEntered = (() => {
+    if (!toSel) return false;
+    try {
+      return parseUnits(toAmount || '0', toSel.decimals) > 0n;
     } catch {
       return false;
     }
@@ -207,19 +250,27 @@ export function SwapWidget({ className }: SwapWidgetProps) {
 
   const handleSwap = () => {
     if (!canSwap || !fromSel || !toSel || fee === null) return;
-    const units = parseUnits(fromAmount, fromSel.decimals);
+    const amountOut = parseUnits(toAmount, toSel.decimals);
     setSwapping(true);
     midnight
-      .swap(fromSel.erc20Address, toSel.erc20Address, units, fee, slippageBps)
+      .swap(
+        fromSel.erc20Address,
+        toSel.erc20Address,
+        amountOut,
+        fee,
+        slippageBps,
+      )
       .then(() => {
         setFromAmount('');
         setToAmount('');
       })
-      .catch((e: unknown) => toast.error(e instanceof Error ? e.message : 'Swap failed'))
+      .catch((e: unknown) =>
+        toast.error(e instanceof Error ? e.message : 'Swap failed'),
+      )
       .finally(() => setSwapping(false));
   };
 
-  const noPool = amountValid && !quoting && fee === null;
+  const noPool = outEntered && !quoting && fee === null;
   const buttonLabel = !enabled
     ? 'Connect Midnight to swap'
     : swappablePairs === null
@@ -257,8 +308,9 @@ export function SwapWidget({ className }: SwapWidgetProps) {
           <DialogHeader>
             <DialogTitle>Swap settings</DialogTitle>
             <DialogDescription>
-              Max slippage — the swap reverts on-chain if the output falls below this
-              tolerance of the quote.
+              Max slippage — you receive the exact output; the swap reverts
+              on-chain if the required input exceeds this tolerance above the
+              quote.
             </DialogDescription>
           </DialogHeader>
           <div className='flex flex-wrap gap-2'>
@@ -279,7 +331,7 @@ export function SwapWidget({ className }: SwapWidgetProps) {
       <div className='flex flex-col gap-4'>
         <TokenAmountDisplay
           value={fromAmount}
-          onChange={setFromAmount}
+          onChange={() => {}}
           tokens={enabled ? fromTokens : []}
           selectedToken={fromSel}
           onTokenSelect={t => setFromToken(t as TokenWithBalance)}
@@ -293,7 +345,7 @@ export function SwapWidget({ className }: SwapWidgetProps) {
 
         <TokenAmountDisplay
           value={toAmount}
-          onChange={() => {}}
+          onChange={setToAmount}
           tokens={enabled ? toTokens : []}
           selectedToken={toSel}
           onTokenSelect={t => setToToken(t as TokenWithBalance)}

--- a/frontend/components/ui/token-amount-display.tsx
+++ b/frontend/components/ui/token-amount-display.tsx
@@ -25,6 +25,9 @@ interface TokenAmountDisplayProps {
   className?: string;
   placeholder?: string;
   disabled?: boolean;
+  // Amount is computed, not user-entered (e.g. a quote): the input is non-editable and the
+  // `max` shortcut is hidden, but the token dropdown still works so the token can be changed.
+  readOnly?: boolean;
 }
 
 export function TokenAmountDisplay({
@@ -37,6 +40,7 @@ export function TokenAmountDisplay({
   className = '',
   placeholder = '0.00',
   disabled = false,
+  readOnly = false,
 }: TokenAmountDisplayProps) {
   const handleMaxClick = () => {
     if (selectedToken) {
@@ -60,11 +64,12 @@ export function TokenAmountDisplay({
             inputMode='decimal'
             enterKeyHint='done'
             value={value}
-            onChange={e => !disabled && onChange(e.target.value)}
+            onChange={e => !disabled && !readOnly && onChange(e.target.value)}
+            readOnly={readOnly}
             placeholder={placeholder}
             className='text-dark-neutral-500 w-full min-w-0 border-none bg-transparent text-lg outline-none sm:text-xl'
           />
-          {selectedToken && !disabled && (
+          {selectedToken && !disabled && !readOnly && (
             <button
               type='button'
               onClick={handleMaxClick}

--- a/frontend/components/wallet-button.tsx
+++ b/frontend/components/wallet-button.tsx
@@ -118,7 +118,7 @@ export function WalletButton() {
                     </div>
                     <span className='flex flex-col'>
                       <span className='text-sm font-medium text-gray-900'>
-                        Developer wallet
+                        Developer wallet (Midnight)
                       </span>
                       <span className='text-xs text-gray-500'>
                         In-app seed wallet · ledger-9 · Sepolia

--- a/frontend/hooks/use-midnight-progress.ts
+++ b/frontend/hooks/use-midnight-progress.ts
@@ -14,10 +14,13 @@ export function useMidnightProgress(): {
     kind: flow.kind,
     phase: flow.phase,
     error: flow.error,
+    refunded: flow.refunded,
   });
   useEffect(() => flow.subscribe(setS), []);
   return {
-    active: !!s.phase && s.phase !== 'done',
+    // A failed flow is terminal, not active — otherwise its lingering phase would keep the
+    // swap/deposit buttons disabled after an error (flow.fail leaves phase set for the message).
+    active: !!s.phase && s.phase !== 'done' && !s.error,
     message: s.phase ? (PHASE_MESSAGE[s.phase] ?? 'Working…') : 'Working…',
     error: s.error,
   };

--- a/frontend/hooks/use-midnight-transactions.ts
+++ b/frontend/hooks/use-midnight-transactions.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  midnightTxHistory,
+  type MidnightTxRecord,
+} from '@/lib/midnight/tx-history';
+import { formatActivityDate } from '@/lib/utils/date-formatting';
+import type { ActivityTransaction } from '@/components/activity-list-table';
+
+const CHAIN = 'midnight';
+
+// A refund returns the funds but the intended op did not execute, so it reads as a failure in the
+// badge (the details still say "refunded" via the log/toast).
+function toStatus(s: MidnightTxRecord['status']): ActivityTransaction['status'] {
+  if (s === 'completed') return 'completed';
+  if (s === 'pending') return 'pending';
+  return 'failed';
+}
+
+function toActivity(r: MidnightTxRecord): ActivityTransaction {
+  // Match the Redis builder's WALLET convention: deposit's source and withdraw's destination are
+  // the wallet/address side; the other side is the token amount.
+  const fromToken =
+    r.type === 'Deposit'
+      ? { symbol: 'WALLET', chain: CHAIN, amount: r.fromAmount, usdValue: '' }
+      : { symbol: r.fromSymbol, chain: CHAIN, amount: r.fromAmount, usdValue: '' };
+  const toToken =
+    r.type === 'Withdraw'
+      ? { symbol: 'WALLET', chain: CHAIN, amount: r.toAmount, usdValue: '' }
+      : {
+          symbol: r.toSymbol,
+          chain: CHAIN,
+          amount: r.toAmount || r.toSymbol,
+          usdValue: '',
+        };
+  return {
+    id: r.id,
+    type: r.type,
+    fromToken,
+    toToken,
+    address: r.counterparty,
+    timestamp: formatActivityDate(r.timestampRaw),
+    timestampRaw: r.timestampRaw,
+    status: toStatus(r.status),
+    transactionHash: r.txHash,
+    explorerUrl: r.txHash
+      ? `https://sepolia.etherscan.io/tx/${r.txHash}`
+      : undefined,
+  };
+}
+
+/** Live Midnight vault operations mapped to the Activity table's row shape. */
+export function useMidnightTransactions(): ActivityTransaction[] {
+  const [txs, setTxs] = useState<MidnightTxRecord[]>([]);
+  useEffect(() => midnightTxHistory.subscribe(setTxs), []);
+  return txs.map(toActivity);
+}

--- a/frontend/hooks/use-tx-status.ts
+++ b/frontend/hooks/use-tx-status.ts
@@ -39,7 +39,7 @@ export function getStatusLabel(status: TxStatus): string {
     pending: 'Pending',
     balance_polling: 'Waiting for deposit',
     gas_topup_pending: 'Funding gas',
-    solana_pending: 'Processing on Solana',
+    solana_pending: 'Processing on-chain',
     signature_pending: 'Awaiting signature',
     ethereum_pending: 'Processing on Ethereum',
     completing: 'Finalizing',

--- a/frontend/lib/evm/gas-topup.ts
+++ b/frontend/lib/evm/gas-topup.ts
@@ -12,7 +12,10 @@ import { encodeErc20Transfer, estimateFees } from '@/lib/evm/tx-builder';
 import { getRelayerEthAccount } from '@/lib/utils/relayer-setup';
 
 const GAS_BUFFER_MULTIPLIER = 1.5;
-const MAX_TOPUP_ETH = parseEther('0.01');
+// Per-call cap on a single top-up. Must cover the largest single vault tx's upfront reservation:
+// the swap's 700k gas * 30 gwei = 0.021 ETH (plus the route's fee margin + buffer). The old 0.01
+// cap silently under-funded the swap after its gas envelope was raised.
+const MAX_TOPUP_ETH = parseEther('0.05');
 const GAS_LIMIT_BUFFER_PERCENT = 120n;
 const ETH_TRANSFER_GAS = 21000n;
 

--- a/frontend/lib/midnight/contract-exports.ts
+++ b/frontend/lib/midnight/contract-exports.ts
@@ -29,4 +29,8 @@ export const witnesses: Witnesses<VaultPrivateState> = {
 /** The vault declares its signet request index as ledger field 0. */
 export const VAULT_REQUESTS_INDEX_FIELD = 0;
 
+/** Swaps register in a separate map (swapEventMap) at field 11, so the swap flow reads
+ * MPC responses from this position. Must match the `11 as Uint<8>` the swap circuit passes. */
+export const VAULT_SWAP_REQUESTS_INDEX_FIELD = 11;
+
 export { Contract, pureCircuits, ledger };

--- a/frontend/lib/midnight/evm-swap.ts
+++ b/frontend/lib/midnight/evm-swap.ts
@@ -24,8 +24,9 @@ export const APPROVE_SELECTOR = new Uint8Array([0x09, 0x5e, 0xa7, 0xb3]);
 // Effectively-unlimited allowance (matches the contract's approveRouter, 2^128-1).
 export const MAX_APPROVE = 340282366920938463463374607431768211455n;
 
-// A V3 single-hop swap is ~120-200k gas; the contract fixes this envelope (vault pays).
-export const SWAP_GAS_LIMIT = 300_000n;
+// A V3 single-hop swap is ~120-200k gas, but an exact-output swap across a thin/fragmented pool
+// crosses many ticks, so the cap has headroom. Must match the contract's fixed swap gas envelope.
+export const SWAP_GAS_LIMIT = 700_000n;
 export const SWAP_MAX_FEE_PER_GAS = 30_000_000_000n;
 export const SWAP_MAX_PRIORITY_FEE_PER_GAS = 1_000_000_000n;
 
@@ -53,6 +54,7 @@ export const SWAP_MPC_ROUTING = {
 
 const QUOTER_ABI = [
   'function quoteExactOutputSingle((address tokenIn,address tokenOut,uint256 amount,uint24 fee,uint160 sqrtPriceLimitX96)) returns (uint256 amountIn,uint160 sqrtPriceX96After,uint32 initializedTicksCrossed,uint256 gasEstimate)',
+  'function quoteExactInputSingle((address tokenIn,address tokenOut,uint256 amountIn,uint24 fee,uint160 sqrtPriceLimitX96)) returns (uint256 amountOut,uint160 sqrtPriceX96After,uint32 initializedTicksCrossed,uint256 gasEstimate)',
 ];
 
 /** Whether the Uniswap router is deployed at `evmRpcUrl` (true on Sepolia + the fork). */
@@ -139,6 +141,65 @@ export async function quoteBestFee(
         amountInMaximum: r.value.amountInMaximum,
         fee: r.value.fee,
       };
+    }
+  }
+  return best;
+}
+
+/**
+ * Live QuoterV2 quote for exactInputSingle (read-only `eth_call`): the `amountOut` a swap of
+ * `amountIn` would yield at `fee`. Drives the normal swap UX — the user types the spend, we show
+ * the expected receive — while the on-chain swap stays exactOutput (see `quoteBestFeeExactInput`).
+ */
+export async function quoteExactInputSingle(
+  evmRpcUrl: string,
+  tokenIn: string,
+  tokenOut: string,
+  fee: bigint,
+  amountIn: bigint,
+): Promise<{ amountOut: bigint }> {
+  const quoter = new EthersContract(
+    UNISWAP_QUOTER_V2,
+    QUOTER_ABI,
+    new JsonRpcProvider(evmRpcUrl),
+  );
+  const [amountOut] = await quoter
+    .getFunction('quoteExactInputSingle')
+    .staticCall({
+      tokenIn,
+      tokenOut,
+      amountIn,
+      fee,
+      sqrtPriceLimitX96: 0n,
+    });
+  return { amountOut: BigInt(amountOut) };
+}
+
+/**
+ * Quote a desired `amountIn` (the spend) across every fee tier and return the tier giving the
+ * BEST (highest) `amountOut` — the pool the swap should use. `null` means no pool for this pair at
+ * any tier. The caller applies slippage to `amountOut` to derive the exactOutput target.
+ */
+export async function quoteBestFeeExactInput(
+  evmRpcUrl: string,
+  tokenIn: string,
+  tokenOut: string,
+  amountIn: bigint,
+): Promise<{ amountOut: bigint; fee: bigint } | null> {
+  const results = await Promise.allSettled(
+    UNISWAP_FEE_TIERS.map(async fee => ({
+      fee,
+      ...(await quoteExactInputSingle(evmRpcUrl, tokenIn, tokenOut, fee, amountIn)),
+    })),
+  );
+  let best: { amountOut: bigint; fee: bigint } | null = null;
+  for (const r of results) {
+    if (
+      r.status === 'fulfilled' &&
+      r.value.amountOut > 0n &&
+      (!best || r.value.amountOut > best.amountOut)
+    ) {
+      best = { amountOut: r.value.amountOut, fee: r.value.fee };
     }
   }
   return best;

--- a/frontend/lib/midnight/evm-swap.ts
+++ b/frontend/lib/midnight/evm-swap.ts
@@ -1,0 +1,161 @@
+// Uniswap V3 constants + a read-only QuoterV2 quote for the swap leg. Mirrors the
+// reference integration tests' evm-swap.ts. The router is what the vault's approveRouter
+// grants an allowance to and what a swap targets; the quoter is a read-only price oracle.
+import { Contract as EthersContract, JsonRpcProvider } from 'ethers';
+import {
+  MPC_PARAMS_BYTES,
+  MPCDestination,
+  MPCSignatureAlgorithm,
+  asciiPadded,
+} from '@sig-net/midnight';
+
+// Uniswap V3 on Sepolia (also present on a Sepolia fork).
+export const UNISWAP_SWAP_ROUTER_02 = '0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E';
+export const UNISWAP_QUOTER_V2 = '0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3';
+export const UNISWAP_V3_FACTORY = '0x0227628f3F023bb0B980b67D528571c95c6DaC1c';
+
+// exactInputSingle((address,address,uint24,address,uint256,uint256,uint160)) -> uint256.
+export const EXACT_INPUT_SINGLE_SELECTOR = new Uint8Array([0x04, 0xe4, 0x5a, 0xaf]);
+// approve(address,uint256) -> bool.
+export const APPROVE_SELECTOR = new Uint8Array([0x09, 0x5e, 0xa7, 0xb3]);
+// Effectively-unlimited allowance (matches the contract's approveRouter, 2^128-1).
+export const MAX_APPROVE = 340282366920938463463374607431768211455n;
+
+// A V3 single-hop swap is ~120-200k gas; the contract fixes this envelope (vault pays).
+export const SWAP_GAS_LIMIT = 300_000n;
+export const SWAP_MAX_FEE_PER_GAS = 30_000_000_000n;
+export const SWAP_MAX_PRIORITY_FEE_PER_GAS = 1_000_000_000n;
+
+// The exactInputSingle result schema (must byte-match the contract's swapResponseSchema).
+export const SWAP_RESULT_SCHEMA = '[{"name":"amountOut","type":"uint256"}]';
+export const SWAP_SCHEMA_BYTES = SWAP_RESULT_SCHEMA.length;
+
+// The contract-fixed routing of a swap event (the swap-schema variant of the vault routing).
+export const SWAP_MPC_ROUTING = {
+  algo: MPCSignatureAlgorithm.ecdsa,
+  dest: MPCDestination.unused,
+  params: new Uint8Array(MPC_PARAMS_BYTES),
+  outputDeserializationSchema: asciiPadded(SWAP_RESULT_SCHEMA, SWAP_SCHEMA_BYTES),
+  respondSerializationSchema: asciiPadded(SWAP_RESULT_SCHEMA, SWAP_SCHEMA_BYTES),
+};
+
+const QUOTER_ABI = [
+  'function quoteExactInputSingle((address tokenIn,address tokenOut,uint256 amountIn,uint24 fee,uint160 sqrtPriceLimitX96)) returns (uint256 amountOut,uint160 sqrtPriceX96After,uint32 initializedTicksCrossed,uint256 gasEstimate)',
+];
+
+/** Whether the Uniswap router is deployed at `evmRpcUrl` (true on Sepolia + the fork). */
+export async function uniswapAvailable(evmRpcUrl: string): Promise<boolean> {
+  const code = await new JsonRpcProvider(evmRpcUrl).getCode(UNISWAP_SWAP_ROUTER_02);
+  return code !== '0x';
+}
+
+/**
+ * Live QuoterV2 quote for exactInputSingle (a read-only `eth_call`, no state change), plus
+ * the `amountOutMin` after applying `slippageBps`. This is what the UI shows and what the
+ * swap circuit binds as the on-chain slippage floor.
+ */
+export async function quoteExactInputSingle(
+  evmRpcUrl: string,
+  tokenIn: string,
+  tokenOut: string,
+  fee: bigint,
+  amountIn: bigint,
+  slippageBps = 100n, // 1%
+): Promise<{ amountOut: bigint; amountOutMin: bigint }> {
+  const quoter = new EthersContract(UNISWAP_QUOTER_V2, QUOTER_ABI, new JsonRpcProvider(evmRpcUrl));
+  const [amountOut] = await quoter.getFunction('quoteExactInputSingle').staticCall({
+    tokenIn,
+    tokenOut,
+    amountIn,
+    fee,
+    sqrtPriceLimitX96: 0n,
+  });
+  const amountOutMin = (BigInt(amountOut) * (10_000n - slippageBps)) / 10_000n;
+  return { amountOut: BigInt(amountOut), amountOutMin };
+}
+
+// The Uniswap V3 fee tiers, in bps*100 (0.01% / 0.05% / 0.3% / 1%). Different pairs live in
+// different tiers (e.g. USDC/EURC is 0.05%, a USDC/DAI pool may only exist at 0.01% or 0.3%),
+// so the UI must discover which tier actually has a pool rather than assume one.
+export const UNISWAP_FEE_TIERS = [100n, 500n, 3000n, 10000n];
+
+/**
+ * Quote across every fee tier and return the best (a tier with no pool reverts, so it's
+ * skipped). Returns the winning tier's `fee` so the swap binds the SAME pool the quote used.
+ * `null` means no pool for this pair at any tier.
+ */
+export async function quoteBestFee(
+  evmRpcUrl: string,
+  tokenIn: string,
+  tokenOut: string,
+  amountIn: bigint,
+  slippageBps = 100n,
+): Promise<{ amountOut: bigint; amountOutMin: bigint; fee: bigint } | null> {
+  const results = await Promise.allSettled(
+    UNISWAP_FEE_TIERS.map(async fee => ({
+      fee,
+      ...(await quoteExactInputSingle(evmRpcUrl, tokenIn, tokenOut, fee, amountIn, slippageBps)),
+    })),
+  );
+  let best: { amountOut: bigint; amountOutMin: bigint; fee: bigint } | null = null;
+  for (const r of results) {
+    if (r.status === 'fulfilled' && r.value.amountOut > 0n && (!best || r.value.amountOut > best.amountOut)) {
+      best = { amountOut: r.value.amountOut, amountOutMin: r.value.amountOutMin, fee: r.value.fee };
+    }
+  }
+  return best;
+}
+
+// A normalized, order-independent key for a token pair (both lowercased + sorted).
+export function pairKey(tokenA: string, tokenB: string): string {
+  return [tokenA.toLowerCase(), tokenB.toLowerCase()].sort().join('|');
+}
+
+const FACTORY_ABI = ['function getPool(address,address,uint24) view returns (address)'];
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+/**
+ * Which of the given token pairs have a direct V3 pool at any fee tier. Returns a set of
+ * `pairKey`s so the UI can offer only swappable pairs (a token with no pool to anything is
+ * hidden entirely). One factory `getPool` per (pair, tier) — cheap read-only `eth_call`s.
+ */
+export async function discoverSwappablePairs(
+  evmRpcUrl: string,
+  tokens: string[],
+): Promise<Set<string>> {
+  const factory = new EthersContract(UNISWAP_V3_FACTORY, FACTORY_ABI, new JsonRpcProvider(evmRpcUrl));
+  const getPool = factory.getFunction('getPool');
+  const swappable = new Set<string>();
+  const checks: Promise<void>[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    for (let j = i + 1; j < tokens.length; j++) {
+      const a = tokens[i]!;
+      const b = tokens[j]!;
+      for (const fee of UNISWAP_FEE_TIERS) {
+        checks.push(
+          getPool(a, b, fee)
+            .then((pool: string) => {
+              if (pool && pool !== ZERO_ADDRESS) swappable.add(pairKey(a, b));
+            })
+            .catch(() => {}),
+        );
+      }
+    }
+  }
+  await Promise.all(checks);
+  return swappable;
+}
+
+/** The live vault->router allowance for a token (0 means approveRouter is needed once). */
+export async function routerAllowance(
+  evmRpcUrl: string,
+  erc20Hex: string,
+  vaultEvmAddress: string,
+): Promise<bigint> {
+  const token = new EthersContract(
+    erc20Hex,
+    ['function allowance(address,address) view returns (uint256)'],
+    new JsonRpcProvider(evmRpcUrl),
+  );
+  return BigInt(await token.getFunction('allowance')(vaultEvmAddress, UNISWAP_SWAP_ROUTER_02));
+}

--- a/frontend/lib/midnight/evm-swap.ts
+++ b/frontend/lib/midnight/evm-swap.ts
@@ -10,12 +10,15 @@ import {
 } from '@sig-net/midnight';
 
 // Uniswap V3 on Sepolia (also present on a Sepolia fork).
-export const UNISWAP_SWAP_ROUTER_02 = '0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E';
+export const UNISWAP_SWAP_ROUTER_02 =
+  '0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E';
 export const UNISWAP_QUOTER_V2 = '0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3';
 export const UNISWAP_V3_FACTORY = '0x0227628f3F023bb0B980b67D528571c95c6DaC1c';
 
-// exactInputSingle((address,address,uint24,address,uint256,uint256,uint160)) -> uint256.
-export const EXACT_INPUT_SINGLE_SELECTOR = new Uint8Array([0x04, 0xe4, 0x5a, 0xaf]);
+// exactOutputSingle((address,address,uint24,address,uint256,uint256,uint160)) -> uint256 amountIn.
+export const EXACT_OUTPUT_SINGLE_SELECTOR = new Uint8Array([
+  0x50, 0x23, 0xb4, 0xdf,
+]);
 // approve(address,uint256) -> bool.
 export const APPROVE_SELECTOR = new Uint8Array([0x09, 0x5e, 0xa7, 0xb3]);
 // Effectively-unlimited allowance (matches the contract's approveRouter, 2^128-1).
@@ -26,52 +29,71 @@ export const SWAP_GAS_LIMIT = 300_000n;
 export const SWAP_MAX_FEE_PER_GAS = 30_000_000_000n;
 export const SWAP_MAX_PRIORITY_FEE_PER_GAS = 1_000_000_000n;
 
-// The exactInputSingle result schema (must byte-match the contract's swapResponseSchema).
-export const SWAP_RESULT_SCHEMA = '[{"name":"amountOut","type":"uint256"}]';
-export const SWAP_SCHEMA_BYTES = SWAP_RESULT_SCHEMA.length;
+// exactOutputSingle returns amountIn (uint256); the MPC re-packs it as uint64 for the
+// attestation. Two schemas — must byte-match the contract's swapOutputSchema / swapRespondSchema.
+export const SWAP_OUTPUT_SCHEMA = '[{"name":"amountIn","type":"uint256"}]';
+export const SWAP_RESPOND_SCHEMA = '[{"name":"amountIn","type":"uint64"}]';
+export const SWAP_OUTPUT_SCHEMA_BYTES = SWAP_OUTPUT_SCHEMA.length;
+export const SWAP_RESPOND_SCHEMA_BYTES = SWAP_RESPOND_SCHEMA.length;
 
 // The contract-fixed routing of a swap event (the swap-schema variant of the vault routing).
 export const SWAP_MPC_ROUTING = {
   algo: MPCSignatureAlgorithm.ecdsa,
   dest: MPCDestination.unused,
   params: new Uint8Array(MPC_PARAMS_BYTES),
-  outputDeserializationSchema: asciiPadded(SWAP_RESULT_SCHEMA, SWAP_SCHEMA_BYTES),
-  respondSerializationSchema: asciiPadded(SWAP_RESULT_SCHEMA, SWAP_SCHEMA_BYTES),
+  outputDeserializationSchema: asciiPadded(
+    SWAP_OUTPUT_SCHEMA,
+    SWAP_OUTPUT_SCHEMA_BYTES,
+  ),
+  respondSerializationSchema: asciiPadded(
+    SWAP_RESPOND_SCHEMA,
+    SWAP_RESPOND_SCHEMA_BYTES,
+  ),
 };
 
 const QUOTER_ABI = [
-  'function quoteExactInputSingle((address tokenIn,address tokenOut,uint256 amountIn,uint24 fee,uint160 sqrtPriceLimitX96)) returns (uint256 amountOut,uint160 sqrtPriceX96After,uint32 initializedTicksCrossed,uint256 gasEstimate)',
+  'function quoteExactOutputSingle((address tokenIn,address tokenOut,uint256 amount,uint24 fee,uint160 sqrtPriceLimitX96)) returns (uint256 amountIn,uint160 sqrtPriceX96After,uint32 initializedTicksCrossed,uint256 gasEstimate)',
 ];
 
 /** Whether the Uniswap router is deployed at `evmRpcUrl` (true on Sepolia + the fork). */
 export async function uniswapAvailable(evmRpcUrl: string): Promise<boolean> {
-  const code = await new JsonRpcProvider(evmRpcUrl).getCode(UNISWAP_SWAP_ROUTER_02);
+  const code = await new JsonRpcProvider(evmRpcUrl).getCode(
+    UNISWAP_SWAP_ROUTER_02,
+  );
   return code !== '0x';
 }
 
 /**
- * Live QuoterV2 quote for exactInputSingle (a read-only `eth_call`, no state change), plus
- * the `amountOutMin` after applying `slippageBps`. This is what the UI shows and what the
- * swap circuit binds as the on-chain slippage floor.
+ * Live QuoterV2 quote for exactOutputSingle (a read-only `eth_call`, no state change): the
+ * `amountIn` needed to receive `amountOut`, plus the `amountInMaximum` after applying
+ * `slippageBps` (headroom ABOVE the quote). This is what the UI shows and what the swap circuit
+ * binds as the on-chain slippage cap.
  */
-export async function quoteExactInputSingle(
+export async function quoteExactOutputSingle(
   evmRpcUrl: string,
   tokenIn: string,
   tokenOut: string,
   fee: bigint,
-  amountIn: bigint,
+  amountOut: bigint,
   slippageBps = 100n, // 1%
-): Promise<{ amountOut: bigint; amountOutMin: bigint }> {
-  const quoter = new EthersContract(UNISWAP_QUOTER_V2, QUOTER_ABI, new JsonRpcProvider(evmRpcUrl));
-  const [amountOut] = await quoter.getFunction('quoteExactInputSingle').staticCall({
-    tokenIn,
-    tokenOut,
-    amountIn,
-    fee,
-    sqrtPriceLimitX96: 0n,
-  });
-  const amountOutMin = (BigInt(amountOut) * (10_000n - slippageBps)) / 10_000n;
-  return { amountOut: BigInt(amountOut), amountOutMin };
+): Promise<{ amountIn: bigint; amountInMaximum: bigint }> {
+  const quoter = new EthersContract(
+    UNISWAP_QUOTER_V2,
+    QUOTER_ABI,
+    new JsonRpcProvider(evmRpcUrl),
+  );
+  const [amountIn] = await quoter
+    .getFunction('quoteExactOutputSingle')
+    .staticCall({
+      tokenIn,
+      tokenOut,
+      amount: amountOut,
+      fee,
+      sqrtPriceLimitX96: 0n,
+    });
+  const amountInMaximum =
+    (BigInt(amountIn) * (10_000n + slippageBps)) / 10_000n;
+  return { amountIn: BigInt(amountIn), amountInMaximum };
 }
 
 // The Uniswap V3 fee tiers, in bps*100 (0.01% / 0.05% / 0.3% / 1%). Different pairs live in
@@ -80,27 +102,43 @@ export async function quoteExactInputSingle(
 export const UNISWAP_FEE_TIERS = [100n, 500n, 3000n, 10000n];
 
 /**
- * Quote across every fee tier and return the best (a tier with no pool reverts, so it's
- * skipped). Returns the winning tier's `fee` so the swap binds the SAME pool the quote used.
- * `null` means no pool for this pair at any tier.
+ * Quote across every fee tier for a desired `amountOut` and return the CHEAPEST (lowest
+ * amountIn; a tier with no pool reverts, so it's skipped). Returns the winning tier's `fee` so
+ * the swap binds the SAME pool the quote used. `null` means no pool for this pair at any tier.
  */
 export async function quoteBestFee(
   evmRpcUrl: string,
   tokenIn: string,
   tokenOut: string,
-  amountIn: bigint,
+  amountOut: bigint,
   slippageBps = 100n,
-): Promise<{ amountOut: bigint; amountOutMin: bigint; fee: bigint } | null> {
+): Promise<{ amountIn: bigint; amountInMaximum: bigint; fee: bigint } | null> {
   const results = await Promise.allSettled(
     UNISWAP_FEE_TIERS.map(async fee => ({
       fee,
-      ...(await quoteExactInputSingle(evmRpcUrl, tokenIn, tokenOut, fee, amountIn, slippageBps)),
+      ...(await quoteExactOutputSingle(
+        evmRpcUrl,
+        tokenIn,
+        tokenOut,
+        fee,
+        amountOut,
+        slippageBps,
+      )),
     })),
   );
-  let best: { amountOut: bigint; amountOutMin: bigint; fee: bigint } | null = null;
+  let best: { amountIn: bigint; amountInMaximum: bigint; fee: bigint } | null =
+    null;
   for (const r of results) {
-    if (r.status === 'fulfilled' && r.value.amountOut > 0n && (!best || r.value.amountOut > best.amountOut)) {
-      best = { amountOut: r.value.amountOut, amountOutMin: r.value.amountOutMin, fee: r.value.fee };
+    if (
+      r.status === 'fulfilled' &&
+      r.value.amountIn > 0n &&
+      (!best || r.value.amountIn < best.amountIn)
+    ) {
+      best = {
+        amountIn: r.value.amountIn,
+        amountInMaximum: r.value.amountInMaximum,
+        fee: r.value.fee,
+      };
     }
   }
   return best;
@@ -111,7 +149,9 @@ export function pairKey(tokenA: string, tokenB: string): string {
   return [tokenA.toLowerCase(), tokenB.toLowerCase()].sort().join('|');
 }
 
-const FACTORY_ABI = ['function getPool(address,address,uint24) view returns (address)'];
+const FACTORY_ABI = [
+  'function getPool(address,address,uint24) view returns (address)',
+];
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 /**
@@ -123,7 +163,11 @@ export async function discoverSwappablePairs(
   evmRpcUrl: string,
   tokens: string[],
 ): Promise<Set<string>> {
-  const factory = new EthersContract(UNISWAP_V3_FACTORY, FACTORY_ABI, new JsonRpcProvider(evmRpcUrl));
+  const factory = new EthersContract(
+    UNISWAP_V3_FACTORY,
+    FACTORY_ABI,
+    new JsonRpcProvider(evmRpcUrl),
+  );
   const getPool = factory.getFunction('getPool');
   const swappable = new Set<string>();
   const checks: Promise<void>[] = [];
@@ -157,5 +201,10 @@ export async function routerAllowance(
     ['function allowance(address,address) view returns (uint256)'],
     new JsonRpcProvider(evmRpcUrl),
   );
-  return BigInt(await token.getFunction('allowance')(vaultEvmAddress, UNISWAP_SWAP_ROUTER_02));
+  return BigInt(
+    await token.getFunction('allowance')(
+      vaultEvmAddress,
+      UNISWAP_SWAP_ROUTER_02,
+    ),
+  );
 }

--- a/frontend/lib/midnight/flow.ts
+++ b/frontend/lib/midnight/flow.ts
@@ -7,12 +7,16 @@ export type FlowPhase =
   | 'proving'
   | 'settling'
   | 'claim-proving'
+  | 'refunding'
   | 'done';
 
 export type FlowState = {
   kind: FlowKind | null;
   phase: FlowPhase | null;
   error: string | null;
+  // Set once the flow ends by refunding (the on-chain leg failed but funds were re-minted), so
+  // the UI can show a distinct "didn't execute — refunded" terminal instead of a success.
+  refunded: boolean;
 };
 
 type Listener = (s: FlowState) => void;
@@ -21,21 +25,24 @@ class Flow {
   kind: FlowKind | null = null;
   phase: FlowPhase | null = null;
   error: string | null = null;
+  refunded = false;
   private listeners = new Set<Listener>();
 
   start(kind: FlowKind) {
-    this.kind = kind; this.phase = 'preparing'; this.error = null; this.emit();
+    this.kind = kind; this.phase = 'preparing'; this.error = null; this.refunded = false; this.emit();
   }
   set(phase: FlowPhase) { this.phase = phase; this.error = null; this.emit(); }
   fail(message: string) { this.error = message; this.emit(); }
-  reset() { this.kind = null; this.phase = null; this.error = null; this.emit(); }
+  // Terminal reached via refund: the on-chain leg failed but the surrendered funds were re-minted.
+  finishRefunded() { this.phase = 'done'; this.refunded = true; this.emit(); }
+  reset() { this.kind = null; this.phase = null; this.error = null; this.refunded = false; this.emit(); }
 
   subscribe(l: Listener): () => void {
     this.listeners.add(l);
     l(this.snapshot());
     return () => { this.listeners.delete(l); };
   }
-  private snapshot(): FlowState { return { kind: this.kind, phase: this.phase, error: this.error }; }
+  private snapshot(): FlowState { return { kind: this.kind, phase: this.phase, error: this.error, refunded: this.refunded }; }
   private emit() { const s = this.snapshot(); for (const l of this.listeners) l(s); }
 }
 
@@ -46,5 +53,6 @@ export const PHASE_MESSAGE: Record<FlowPhase, string> = {
   proving: 'Generating proof (runs locally, can take minutes)…',
   settling: 'MPC signing + settling on Sepolia…',
   'claim-proving': 'Generating settlement proof…',
+  refunding: 'On-chain leg failed — refunding your tokens…',
   done: 'Done',
 };

--- a/frontend/lib/midnight/flow.ts
+++ b/frontend/lib/midnight/flow.ts
@@ -1,6 +1,6 @@
-// Deposit/withdraw lifecycle state; vault.ts pushes phases, the UI subscribes.
+// Deposit/withdraw/swap lifecycle state; vault.ts pushes phases, the UI subscribes.
 
-export type FlowKind = 'deposit' | 'withdraw';
+export type FlowKind = 'deposit' | 'withdraw' | 'swap';
 
 export type FlowPhase =
   | 'preparing'

--- a/frontend/lib/midnight/tx-history.ts
+++ b/frontend/lib/midnight/tx-history.ts
@@ -1,0 +1,56 @@
+'use client';
+
+// Session-scoped history of Midnight vault operations (deposit / withdraw / swap) for the Activity
+// table. Unlike the Ethereum (Redis) and Solana sources, the vault flows leave no server-side
+// record, so this in-memory observable log lets the Activity list show them alongside the other
+// chains. It resets on reload — the vault's authoritative state is the shielded balance, not this.
+
+export type MidnightTxType = 'Deposit' | 'Withdraw' | 'Swap';
+export type MidnightTxStatus = 'pending' | 'completed' | 'failed' | 'refunded';
+
+export interface MidnightTxRecord {
+  id: string;
+  type: MidnightTxType;
+  fromSymbol: string;
+  fromAmount: string; // pre-formatted, may be an address for the WALLET side
+  toSymbol: string;
+  toAmount: string;
+  counterparty?: string; // deposit address / withdraw destination
+  status: MidnightTxStatus;
+  timestampRaw: number; // unix seconds
+  txHash?: string; // Sepolia tx hash, when known
+}
+
+type Listener = (txs: MidnightTxRecord[]) => void;
+
+class MidnightTxHistory {
+  private txs: MidnightTxRecord[] = [];
+  private listeners = new Set<Listener>();
+
+  /** Insert (or replace by id) a record, newest first. */
+  add(rec: MidnightTxRecord) {
+    this.txs = [rec, ...this.txs.filter(t => t.id !== rec.id)];
+    this.emit();
+  }
+
+  /** Patch an existing record (e.g. pending -> completed/failed/refunded, add a tx hash). */
+  update(id: string, patch: Partial<MidnightTxRecord>) {
+    this.txs = this.txs.map(t => (t.id === id ? { ...t, ...patch } : t));
+    this.emit();
+  }
+
+  subscribe(l: Listener): () => void {
+    this.listeners.add(l);
+    l(this.txs);
+    return () => {
+      this.listeners.delete(l);
+    };
+  }
+
+  private emit() {
+    const snap = this.txs;
+    for (const l of this.listeners) l(snap);
+  }
+}
+
+export const midnightTxHistory = new MidnightTxHistory();

--- a/frontend/lib/midnight/vault.ts
+++ b/frontend/lib/midnight/vault.ts
@@ -34,7 +34,25 @@ import {
   ERC20_TRANSFER_MAX_FEE_PER_GAS as MAX_FEE,
   ERC20_TRANSFER_MAX_PRIORITY_FEE_PER_GAS as PRIORITY_FEE,
 } from './evm-envelope';
-import { pureCircuits, ledger, VAULT_REQUESTS_INDEX_FIELD } from './contract-exports';
+import {
+  pureCircuits,
+  ledger,
+  VAULT_REQUESTS_INDEX_FIELD,
+  VAULT_SWAP_REQUESTS_INDEX_FIELD,
+} from './contract-exports';
+import {
+  APPROVE_SELECTOR,
+  EXACT_INPUT_SINGLE_SELECTOR,
+  MAX_APPROVE,
+  SWAP_GAS_LIMIT,
+  SWAP_MAX_FEE_PER_GAS,
+  SWAP_MAX_PRIORITY_FEE_PER_GAS,
+  SWAP_MPC_ROUTING,
+  SWAP_RESULT_SCHEMA,
+  UNISWAP_SWAP_ROUTER_02,
+  quoteExactInputSingle,
+  routerAllowance,
+} from './evm-swap';
 
 // Fixed EVM transfer envelope + MPC routing (mirrors the reference integration tests).
 const ERC20_TRANSFER_SELECTOR = new Uint8Array([0xa9, 0x05, 0x9c, 0xbb]);
@@ -107,10 +125,14 @@ async function readVaultLedger(providers: any, env: Env): Promise<any> {
   return (ledger as any)(cs.data);
 }
 
-function responseReader(providers: any, env: Env): SignetRequestResponseReader {
+function responseReader(
+  providers: any,
+  env: Env,
+  indexField: number = VAULT_REQUESTS_INDEX_FIELD,
+): SignetRequestResponseReader {
   return new SignetRequestResponseReader({
     requesterContractAddress: env.contractAddress,
-    requesterRequestsIndexField: VAULT_REQUESTS_INDEX_FIELD,
+    requesterRequestsIndexField: indexField,
     signetContractAddress: env.signetContractAddress,
     publicDataProvider: providers.publicDataProvider,
   } as any);
@@ -164,6 +186,58 @@ async function assertRequestOnLedger(providers: any, env: Env, rid: RequestIdHex
   }
 }
 
+// Swaps register in swapEventMap (field 11), a separate map from the transfer map above.
+async function assertSwapRequestOnLedger(providers: any, env: Env, rid: RequestIdHex) {
+  const after = await readVaultLedger(providers, env);
+  if (!toSignBidirectionalEventIndex(after.swapEventMap).has(rid)) {
+    throw new Error(`swap request ${rid} not on the ledger after swap()`);
+  }
+}
+
+// Predict the request id for any EVM call the vault records: the full request record hashed.
+// Generalises predictRequestId over the calldata (selector + ABI words), the gas envelope
+// and the MPC routing, so approve (2-word transfer schema) and swap (7-word amountOut
+// schema) share one builder.
+function predictCallRequestId(
+  env: Env,
+  before: any,
+  path: Uint8Array,
+  nonce: bigint,
+  to: Uint8Array,
+  routing: any,
+  gasLimit: bigint,
+  maxFee: bigint,
+  priorityFee: bigint,
+  selector: Uint8Array,
+  words: Uint8Array[],
+): RequestIdHex {
+  const expected: SignBidirectionalEvent = {
+    sender: { bytes: addrBytes(env.contractAddress) },
+    requestNonce: before.signetRequestNonce,
+    keyVersion: SIGNET_DEFAULT_KEY_VERSION,
+    path,
+    ...routing,
+    txParamType: TxParamType.evmType2,
+    caip2Id: before.caip2Id,
+    txParams: {
+      to,
+      chainId: before.evmChainId,
+      nonce,
+      gasLimit,
+      maxFeePerGas: maxFee,
+      maxPriorityFeePerGas: priorityFee,
+      value: 0n,
+      accessListEntryCount: 0n,
+      accessList: [],
+      calldata: {
+        is_some: true,
+        value: { selector, noWords: BigInt(words.length), words },
+      },
+    },
+  } as any;
+  return requestIdHex(calculateRequestId(expected)) as RequestIdHex;
+}
+
 async function fetchFakenetResponse(env: Env, requestId: string, timeoutMs = 8000): Promise<any> {
   const url = `${env.fakenetResponsesUrl}/responses/${requestId}`;
   const deadline = Date.now() + timeoutMs;
@@ -188,9 +262,10 @@ async function pollSignatureResponse(
   requestId: RequestIdHex,
   expectedSigner: string,
   log: (m: string) => void,
+  indexField: number = VAULT_REQUESTS_INDEX_FIELD,
   timeoutMs = 6 * MINUTE,
 ): Promise<Transaction> {
-  const reader = responseReader(providers, env);
+  const reader = responseReader(providers, env, indexField);
   const end = Date.now() + timeoutMs;
   const warned = new Set<bigint>();
   while (Date.now() < end) {
@@ -234,8 +309,14 @@ async function broadcastEvm(env: Env, tx: Transaction): Promise<void> {
 
 // Stage 2: match the MPC's attestation digest against the recomputed serialized output.
 // The log is unauthenticated — the settle circuits re-verify digest + signature in-circuit.
-async function fetchAttestedRespondOutcome(providers: any, env: Env, requestId: RequestIdHex): Promise<any | undefined> {
-  const events = await responseReader(providers, env).getRespondBidirectionalEvents(requestId);
+async function fetchAttestedRespondOutcome(
+  providers: any,
+  env: Env,
+  requestId: RequestIdHex,
+  indexField: number = VAULT_REQUESTS_INDEX_FIELD,
+  schema: string = RESULT_SCHEMA,
+): Promise<any | undefined> {
+  const events = await responseReader(providers, env, indexField).getRespondBidirectionalEvents(requestId);
   if (events.length === 0) return undefined;
   let cached: any;
   try {
@@ -244,12 +325,14 @@ async function fetchAttestedRespondOutcome(providers: any, env: Env, requestId: 
     return undefined;
   }
   const candidates: { serializedOutput: Uint8Array; isFailure: boolean }[] = [];
-  let decodedSuccess: boolean | undefined;
+  // The transfer schema decodes a bool; the swap schema a uint256 amountOut. Either way
+  // decodedValue is what a success settle mints against (unused for the bool case).
+  let decodedValue: any;
   if (cached.success && cached.output != null) {
     try {
-      const decoded: any = deserializeEvmOutput(RESULT_SCHEMA as any, cached.output);
-      decodedSuccess = decoded.success === true;
-      candidates.push({ serializedOutput: serializeRespondOutput(RESULT_SCHEMA as any, decoded), isFailure: false });
+      const decoded: any = deserializeEvmOutput(schema as any, cached.output);
+      decodedValue = decoded;
+      candidates.push({ serializedOutput: serializeRespondOutput(schema as any, decoded), isFailure: false });
     } catch {
       /* only the failure candidate can match */
     }
@@ -264,7 +347,10 @@ async function fetchAttestedRespondOutcome(providers: any, env: Env, requestId: 
       return {
         event,
         serializedOutput: c.serializedOutput,
-        succeeded: !c.isFailure && decodedSuccess === true,
+        decoded: c.isFailure ? undefined : decodedValue,
+        // Transfer schema only: a decoded bool `success`. Swaps read `decoded.amountOut`
+        // and treat any non-failure match as success (matchedFailureOutput === false).
+        succeeded: !c.isFailure && decodedValue?.success === true,
         matchedFailureOutput: c.isFailure,
       };
     }
@@ -272,21 +358,25 @@ async function fetchAttestedRespondOutcome(providers: any, env: Env, requestId: 
   return undefined;
 }
 
-// MPC round trip shared by deposit + withdraw: signature -> broadcast -> attestation.
+// MPC round trip shared by deposit/withdraw/swap: signature -> broadcast -> attestation.
+// indexField/schema default to the transfer map (field 0, bool); swaps pass field 11 + the
+// uint256 amountOut schema.
 async function settleViaMpc(
   providers: any,
   env: Env,
   rid: RequestIdHex,
   expectedSigner: string,
   log: (m: string) => void,
+  indexField: number = VAULT_REQUESTS_INDEX_FIELD,
+  schema: string = RESULT_SCHEMA,
 ): Promise<any> {
   flow.set('settling');
   log('Waiting for MPC signature + settling on Sepolia...');
-  const signed = await pollSignatureResponse(providers, env, rid, expectedSigner, log);
+  const signed = await pollSignatureResponse(providers, env, rid, expectedSigner, log, indexField);
   await broadcastEvm(env, signed);
   const end = Date.now() + 6 * MINUTE;
   while (Date.now() < end) {
-    const outcome = await fetchAttestedRespondOutcome(providers, env, rid);
+    const outcome = await fetchAttestedRespondOutcome(providers, env, rid, indexField, schema);
     if (outcome) return outcome;
     await sleep(1000);
   }
@@ -374,7 +464,9 @@ export async function runWithdraw(
   flow.set('claim-proving');
   if (outcome.matchedFailureOutput) {
     log('EVM transfer never executed — refunding...');
-    await vault.callTx.refundWithdraw(requestIdBytes(rid), outcome.event, outcome.serializedOutput, rand32());
+    // refundWithdraw + refundSwap are merged into one `refund` circuit; it routes on which
+    // pending-marker map holds the id (refundCommitment here).
+    await vault.callTx.refund(requestIdBytes(rid), outcome.event, outcome.serializedOutput, rand32());
   } else {
     log('Settling completeWithdraw...');
     await vault.callTx.completeWithdraw(requestIdBytes(rid), outcome.event, outcome.serializedOutput, rand32());
@@ -385,4 +477,123 @@ export async function runWithdraw(
 
 async function evmNonce(env: Env, address: string): Promise<bigint> {
   return BigInt(await new JsonRpcProvider(env.evmRpcUrl).getTransactionCount(address));
+}
+
+// Ensure the vault account has approved the router for `erc20Hex`: read the live allowance,
+// and if zero run the approve leg (approveRouter -> MPC sign (field 0) -> broadcast; NO
+// settle). Idempotent and global (one pooled vault account), so a nonzero allowance
+// short-circuits and the first swapper readies a token for everyone.
+async function ensureRouterApproved(
+  providers: any,
+  vault: any,
+  env: Env,
+  erc20Hex: string,
+  log: (m: string) => void,
+) {
+  const vaultEvm = vaultAddress(env);
+  const allowance = await routerAllowance(env.evmRpcUrl, erc20Hex, vaultEvm);
+  if (allowance > 0n) return;
+
+  log('Approving Uniswap router for this token (one-time)...');
+  const erc20 = addrBytes(erc20Hex);
+  const nonce = await evmNonce(env, vaultEvm);
+  const before = await readVaultLedger(providers, env);
+  if (!before.initialized) throw new Error('vault not initialized');
+  const rid = predictCallRequestId(
+    env, before, VAULT_PATH, nonce, erc20, MPC_ROUTING, GAS_LIMIT, MAX_FEE, PRIORITY_FEE,
+    APPROVE_SELECTOR,
+    [evmAddressAbiWord(addrBytes(UNISWAP_SWAP_ROUTER_02)), numericAbiWord(MAX_APPROVE)],
+  );
+  await vault.callTx.approveRouter(erc20, nonce, SIGNET_DEFAULT_KEY_VERSION);
+  await assertRequestOnLedger(providers, env, rid, 'approveRouter');
+
+  // Sign-only: the vault account signs the approve, the client broadcasts it, done.
+  const signed = await pollSignatureResponse(providers, env, rid, vaultEvm, log, VAULT_REQUESTS_INDEX_FIELD, 3 * MINUTE);
+  await broadcastEvm(env, signed);
+  log('Router approved.');
+}
+
+// approveRouter (once) -> quote -> swap() (burns tokenIn coin, records in swapEventMap) ->
+// MPC round trip (field 11) -> completeSwap() mints shielded tokenOut (or refund on EVM
+// failure). The vault account holds the pooled funds and both signs + pays for the swap.
+// `fee` is the Uniswap V3 pool tier the UI discovered for this pair (default 0.05%).
+export async function runSwap(
+  providers: any,
+  vault: any,
+  env: Env,
+  identity: Identity,
+  tokenInHex: string,
+  tokenOutHex: string,
+  amount: bigint,
+  log: (m: string) => void,
+  fee = 500n,
+  slippageBps = 100n,
+) {
+  flow.start('swap');
+  const tokenIn = addrBytes(tokenInHex);
+  const tokenOut = addrBytes(tokenOutHex);
+  const vaultEvm = vaultAddress(env);
+
+  // 1. Ready the router allowance for tokenIn (idempotent, global).
+  flow.set('preparing');
+  await ensureRouterApproved(providers, vault, env, tokenInHex, log);
+
+  // 2. Live QuoterV2 quote at the chosen fee tier -> amountOutMin, the on-chain slippage floor.
+  const { amountOut: quoted, amountOutMin } = await quoteExactInputSingle(
+    env.evmRpcUrl, tokenInHex, tokenOutHex, fee, amount, slippageBps,
+  );
+  log(`Quote: ${amount} in -> ~${quoted} out (min ${amountOutMin}, fee ${fee})`);
+
+  // 3. swap(): surrender (burn) the tokenIn vault coin, record the exactInputSingle request.
+  const nonce = await evmNonce(env, vaultEvm);
+  const before = await readVaultLedger(providers, env);
+  if (!before.initialized) throw new Error('vault not initialized');
+  const rid = predictCallRequestId(
+    env, before, VAULT_PATH, nonce, addrBytes(UNISWAP_SWAP_ROUTER_02),
+    SWAP_MPC_ROUTING, SWAP_GAS_LIMIT, SWAP_MAX_FEE_PER_GAS, SWAP_MAX_PRIORITY_FEE_PER_GAS,
+    EXACT_INPUT_SINGLE_SELECTOR,
+    [
+      evmAddressAbiWord(tokenIn),
+      evmAddressAbiWord(tokenOut),
+      numericAbiWord(fee),
+      evmAddressAbiWord(addrBytes(vaultEvm)),
+      numericAbiWord(amount),
+      numericAbiWord(amountOutMin),
+      numericAbiWord(0n),
+    ],
+  );
+  const coin = {
+    nonce: rand32(),
+    color: hexToBytes(vaultTokenType(tokenInHex, env.contractAddress)),
+    value: amount,
+  };
+
+  flow.set('proving');
+  log('Submitting swap() (surrendering the tokenIn vault coin)...');
+  await vault.callTx.swap(
+    nonce, SIGNET_DEFAULT_KEY_VERSION,
+    { tokenIn, tokenOut, fee, amountIn: amount, amountOutMin },
+    coin,
+  );
+  await assertSwapRequestOnLedger(providers, env, rid);
+
+  // 4. MPC signs the swap with the vault account, broadcasts, attests (field 11 + swap schema).
+  const outcome = await settleViaMpc(
+    providers, env, rid, vaultEvm, log, VAULT_SWAP_REQUESTS_INDEX_FIELD, SWAP_RESULT_SCHEMA,
+  );
+
+  // 5. Settle: completeSwap mints the attested amountOut of tokenOut, or refund re-mints
+  // tokenIn if the EVM swap never executed.
+  flow.set('claim-proving');
+  if (outcome.matchedFailureOutput) {
+    log('Swap did not execute on EVM — refunding tokenIn...');
+    await vault.callTx.refund(requestIdBytes(rid), outcome.event, outcome.serializedOutput, rand32());
+    flow.set('done');
+    log('Swap refunded (did not execute).');
+    return;
+  }
+  log('Settling completeSwap (minting shielded tokenOut)...');
+  await vault.callTx.completeSwap(requestIdBytes(rid), outcome.event, outcome.serializedOutput, rand32());
+  flow.set('done');
+  log(`Swap complete — minted ${outcome.decoded?.amountOut ?? '?'} tokenOut.`);
 }

--- a/frontend/lib/midnight/vault.ts
+++ b/frontend/lib/midnight/vault.ts
@@ -1,5 +1,9 @@
 import { rawTokenType } from '@midnight-ntwrk/compact-runtime';
-import { Contract as EthersContract, JsonRpcProvider, type Transaction } from 'ethers';
+import {
+  Contract as EthersContract,
+  JsonRpcProvider,
+  type Transaction,
+} from 'ethers';
 import {
   calculateRequestId,
   requestIdHex,
@@ -42,15 +46,16 @@ import {
 } from './contract-exports';
 import {
   APPROVE_SELECTOR,
-  EXACT_INPUT_SINGLE_SELECTOR,
+  EXACT_OUTPUT_SINGLE_SELECTOR,
   MAX_APPROVE,
   SWAP_GAS_LIMIT,
   SWAP_MAX_FEE_PER_GAS,
   SWAP_MAX_PRIORITY_FEE_PER_GAS,
   SWAP_MPC_ROUTING,
-  SWAP_RESULT_SCHEMA,
+  SWAP_OUTPUT_SCHEMA,
+  SWAP_RESPOND_SCHEMA,
   UNISWAP_SWAP_ROUTER_02,
-  quoteExactInputSingle,
+  quoteExactOutputSingle,
   routerAllowance,
 } from './evm-swap';
 
@@ -91,26 +96,41 @@ export interface Identity {
 // Buffer (the browser polyfill emits different U+FFFD runs, desyncing the address).
 export function deriveIdentity(secretKey: Uint8Array): Identity {
   const commitment = pureCircuits.userCommitment(secretKey);
-  const pathString = new TextDecoder('utf-8').decode(commitment).replace(/\0/g, '');
+  const pathString = new TextDecoder('utf-8')
+    .decode(commitment)
+    .replace(/\0/g, '');
   return { secretKey, commitment, pathString };
 }
 export function depositAddress(env: Env, identity: Identity): string {
-  return deriveEvmAddress(env.mpcSecpPub, env.contractAddress, identity.pathString);
+  return deriveEvmAddress(
+    env.mpcSecpPub,
+    env.contractAddress,
+    identity.pathString,
+  );
 }
 export function vaultAddress(env: Env): string {
   return deriveEvmAddress(env.mpcSecpPub, env.contractAddress, 'vault');
 }
 
 // Shielded vault-token color for an ERC-20 under this vault.
-export function vaultTokenType(erc20Hex: string, vaultContractAddress: string): string {
+export function vaultTokenType(
+  erc20Hex: string,
+  vaultContractAddress: string,
+): string {
   const raw: any = rawTokenType(
     (pureCircuits as any).vaultTokenDomainSeparator(addrBytes(erc20Hex)),
     vaultContractAddress as any,
   );
-  return (typeof raw === 'string' ? raw : bytesToHex(raw)).replace(/^0x/, '').toLowerCase();
+  return (typeof raw === 'string' ? raw : bytesToHex(raw))
+    .replace(/^0x/, '')
+    .toLowerCase();
 }
 
-export async function erc20Balance(rpcUrl: string, erc20Hex: string, address: string): Promise<bigint> {
+export async function erc20Balance(
+  rpcUrl: string,
+  erc20Hex: string,
+  address: string,
+): Promise<bigint> {
   const token = new EthersContract(
     erc20Hex,
     ['function balanceOf(address) view returns (uint256)'],
@@ -120,7 +140,9 @@ export async function erc20Balance(rpcUrl: string, erc20Hex: string, address: st
 }
 
 async function readVaultLedger(providers: any, env: Env): Promise<any> {
-  const cs = await providers.publicDataProvider.queryContractState(env.contractAddress);
+  const cs = await providers.publicDataProvider.queryContractState(
+    env.contractAddress,
+  );
   if (!cs) throw new Error(`no contract state at ${env.contractAddress}`);
   return (ledger as any)(cs.data);
 }
@@ -179,15 +201,26 @@ function predictRequestId(
   return requestIdHex(calculateRequestId(expected)) as RequestIdHex;
 }
 
-async function assertRequestOnLedger(providers: any, env: Env, rid: RequestIdHex, circuit: string) {
+async function assertRequestOnLedger(
+  providers: any,
+  env: Env,
+  rid: RequestIdHex,
+  circuit: string,
+) {
   const after = await readVaultLedger(providers, env);
-  if (!toSignBidirectionalEventIndex(after.signBidirectionalEventMap).has(rid)) {
+  if (
+    !toSignBidirectionalEventIndex(after.signBidirectionalEventMap).has(rid)
+  ) {
     throw new Error(`request ${rid} not on the ledger after ${circuit}()`);
   }
 }
 
 // Swaps register in swapEventMap (field 11), a separate map from the transfer map above.
-async function assertSwapRequestOnLedger(providers: any, env: Env, rid: RequestIdHex) {
+async function assertSwapRequestOnLedger(
+  providers: any,
+  env: Env,
+  rid: RequestIdHex,
+) {
   const after = await readVaultLedger(providers, env);
   if (!toSignBidirectionalEventIndex(after.swapEventMap).has(rid)) {
     throw new Error(`swap request ${rid} not on the ledger after swap()`);
@@ -238,7 +271,11 @@ function predictCallRequestId(
   return requestIdHex(calculateRequestId(expected)) as RequestIdHex;
 }
 
-async function fetchFakenetResponse(env: Env, requestId: string, timeoutMs = 8000): Promise<any> {
+async function fetchFakenetResponse(
+  env: Env,
+  requestId: string,
+  timeoutMs = 8000,
+): Promise<any> {
   const url = `${env.fakenetResponsesUrl}/responses/${requestId}`;
   const deadline = Date.now() + timeoutMs;
   let last = 'not attempted';
@@ -269,7 +306,11 @@ async function pollSignatureResponse(
   const end = Date.now() + timeoutMs;
   const warned = new Set<bigint>();
   while (Date.now() < end) {
-    const { verified, verdicts } = await reader.getVerifiedSignatureRespondedEvent(requestId, expectedSigner);
+    const { verified, verdicts } =
+      await reader.getVerifiedSignatureRespondedEvent(
+        requestId,
+        expectedSigner,
+      );
     for (const v of verdicts as any[]) {
       if (v.rejectedReason !== undefined && !warned.has(v.count)) {
         warned.add(v.count);
@@ -278,7 +319,10 @@ async function pollSignatureResponse(
     }
     if (verified !== undefined) {
       const request = await reader.getSignatureRequest(requestId);
-      return signBidirectionalEventToSignedEvmTransaction(request, verified) as unknown as Transaction;
+      return signBidirectionalEventToSignedEvmTransaction(
+        request,
+        verified,
+      ) as unknown as Transaction;
     }
     await sleep(1000);
   }
@@ -299,7 +343,11 @@ async function broadcastEvm(env: Env, tx: Transaction): Promise<void> {
     await provider.broadcastTransaction(tx.serialized);
   } catch (e: any) {
     const msg = String(e?.message ?? '').toLowerCase();
-    if (e?.code !== 'NONCE_EXPIRED' && !msg.includes('already known') && !msg.includes('nonce too low'))
+    if (
+      e?.code !== 'NONCE_EXPIRED' &&
+      !msg.includes('already known') &&
+      !msg.includes('nonce too low')
+    )
       throw e;
   }
   const receipt = await provider.waitForTransaction(hash, 1, 3 * MINUTE);
@@ -315,8 +363,13 @@ async function fetchAttestedRespondOutcome(
   requestId: RequestIdHex,
   indexField: number = VAULT_REQUESTS_INDEX_FIELD,
   schema: string = RESULT_SCHEMA,
+  respondSchema: string = schema,
 ): Promise<any | undefined> {
-  const events = await responseReader(providers, env, indexField).getRespondBidirectionalEvents(requestId);
+  const events = await responseReader(
+    providers,
+    env,
+    indexField,
+  ).getRespondBidirectionalEvents(requestId);
   if (events.length === 0) return undefined;
   let cached: any;
   try {
@@ -325,21 +378,28 @@ async function fetchAttestedRespondOutcome(
     return undefined;
   }
   const candidates: { serializedOutput: Uint8Array; isFailure: boolean }[] = [];
-  // The transfer schema decodes a bool; the swap schema a uint256 amountOut. Either way
-  // decodedValue is what a success settle mints against (unused for the bool case).
+  // The transfer schema decodes a bool; the swap OUTPUT schema a uint256 amountIn. The MPC
+  // re-packs against `respondSchema` (equal to `schema` for the symmetric transfer case, but a
+  // narrower uint64 for swap). decodedValue is what a success settle reads (the bool, or amountIn).
   let decodedValue: any;
   if (cached.success && cached.output != null) {
     try {
       const decoded: any = deserializeEvmOutput(schema as any, cached.output);
       decodedValue = decoded;
-      candidates.push({ serializedOutput: serializeRespondOutput(schema as any, decoded), isFailure: false });
+      candidates.push({
+        serializedOutput: serializeRespondOutput(respondSchema as any, decoded),
+        isFailure: false,
+      });
     } catch {
       /* only the failure candidate can match */
     }
   }
   candidates.push({ serializedOutput: MPC_FAILURE_OUTPUT, isFailure: true });
   for (const c of candidates) {
-    const digest = calculateSignetAttestationDigest(requestIdBytes(requestId), c.serializedOutput);
+    const digest = calculateSignetAttestationDigest(
+      requestIdBytes(requestId),
+      c.serializedOutput,
+    );
     const event = (events as any[]).find(e =>
       Buffer.from(e.attestationDigest).equals(Buffer.from(digest)),
     );
@@ -369,18 +429,35 @@ async function settleViaMpc(
   log: (m: string) => void,
   indexField: number = VAULT_REQUESTS_INDEX_FIELD,
   schema: string = RESULT_SCHEMA,
+  respondSchema: string = schema,
 ): Promise<any> {
   flow.set('settling');
   log('Waiting for MPC signature + settling on Sepolia...');
-  const signed = await pollSignatureResponse(providers, env, rid, expectedSigner, log, indexField);
+  const signed = await pollSignatureResponse(
+    providers,
+    env,
+    rid,
+    expectedSigner,
+    log,
+    indexField,
+  );
   await broadcastEvm(env, signed);
   const end = Date.now() + 6 * MINUTE;
   while (Date.now() < end) {
-    const outcome = await fetchAttestedRespondOutcome(providers, env, rid, indexField, schema);
+    const outcome = await fetchAttestedRespondOutcome(
+      providers,
+      env,
+      rid,
+      indexField,
+      schema,
+      respondSchema,
+    );
     if (outcome) return outcome;
     await sleep(1000);
   }
-  throw new Error(`timed out waiting for respond-bidirectional attestation for ${rid}`);
+  throw new Error(
+    `timed out waiting for respond-bidirectional attestation for ${rid}`,
+  );
 }
 
 // deposit() -> MPC round trip -> claim() mints the shielded token.
@@ -401,27 +478,53 @@ export async function runDeposit(
 
   const before = await readVaultLedger(providers, env);
   if (!before.initialized) throw new Error('vault not initialized');
-  const rid = predictRequestId(env, before, identity.commitment, nonce, erc20, before.vaultEvmAddress, amount);
+  const rid = predictRequestId(
+    env,
+    before,
+    identity.commitment,
+    nonce,
+    erc20,
+    before.vaultEvmAddress,
+    amount,
+  );
   log(`Predicted requestId 0x${rid}`);
 
   flow.set('proving');
   log('Submitting deposit() on Midnight...');
-  await vault.callTx.deposit(nonce, GAS_LIMIT, MAX_FEE, PRIORITY_FEE, SIGNET_DEFAULT_KEY_VERSION, {
-    erc20Address: erc20,
-    amount,
-  });
+  await vault.callTx.deposit(
+    nonce,
+    GAS_LIMIT,
+    MAX_FEE,
+    PRIORITY_FEE,
+    SIGNET_DEFAULT_KEY_VERSION,
+    {
+      erc20Address: erc20,
+      amount,
+    },
+  );
   await assertRequestOnLedger(providers, env, rid, 'deposit');
 
   const outcome = await settleViaMpc(providers, env, rid, userEvm, log);
-  if (!outcome.succeeded) throw new Error(`MPC attested deposit ${rid} as FAILED`);
+  if (!outcome.succeeded)
+    throw new Error(`MPC attested deposit ${rid} as FAILED`);
 
   flow.set('claim-proving');
   log('Submitting claim() to mint shielded token...');
   const selfRecipient = {
     is_some: false,
-    value: { is_left: true, left: { bytes: new Uint8Array(32) }, right: { bytes: new Uint8Array(32) } },
+    value: {
+      is_left: true,
+      left: { bytes: new Uint8Array(32) },
+      right: { bytes: new Uint8Array(32) },
+    },
   };
-  await vault.callTx.claim(requestIdBytes(rid), outcome.event, outcome.serializedOutput, rand32(), selfRecipient);
+  await vault.callTx.claim(
+    requestIdBytes(rid),
+    outcome.event,
+    outcome.serializedOutput,
+    rand32(),
+    selfRecipient,
+  );
   flow.set('done');
   log('Deposit complete — shielded token minted.');
 }
@@ -446,7 +549,15 @@ export async function runWithdraw(
 
   const before = await readVaultLedger(providers, env);
   if (!before.initialized) throw new Error('vault not initialized');
-  const rid = predictRequestId(env, before, VAULT_PATH, nonce, erc20, dest, amount);
+  const rid = predictRequestId(
+    env,
+    before,
+    VAULT_PATH,
+    nonce,
+    erc20,
+    dest,
+    amount,
+  );
 
   const coin = {
     nonce: rand32(),
@@ -456,7 +567,12 @@ export async function runWithdraw(
 
   flow.set('proving');
   log('Submitting withdraw() (surrendering the vault coin)...');
-  await vault.callTx.withdraw(nonce, SIGNET_DEFAULT_KEY_VERSION, { erc20Address: erc20, amount, destEvmAddress: dest }, coin);
+  await vault.callTx.withdraw(
+    nonce,
+    SIGNET_DEFAULT_KEY_VERSION,
+    { erc20Address: erc20, amount, destEvmAddress: dest },
+    coin,
+  );
   await assertRequestOnLedger(providers, env, rid, 'withdraw');
 
   const outcome = await settleViaMpc(providers, env, rid, vaultEvm, log);
@@ -466,17 +582,33 @@ export async function runWithdraw(
     log('EVM transfer never executed — refunding...');
     // refundWithdraw + refundSwap are merged into one `refund` circuit; it routes on which
     // pending-marker map holds the id (refundCommitment here).
-    await vault.callTx.refund(requestIdBytes(rid), outcome.event, outcome.serializedOutput, rand32());
+    await vault.callTx.refund(
+      requestIdBytes(rid),
+      outcome.event,
+      outcome.serializedOutput,
+      rand32(),
+    );
   } else {
     log('Settling completeWithdraw...');
-    await vault.callTx.completeWithdraw(requestIdBytes(rid), outcome.event, outcome.serializedOutput, rand32());
+    await vault.callTx.completeWithdraw(
+      requestIdBytes(rid),
+      outcome.event,
+      outcome.serializedOutput,
+      rand32(),
+    );
   }
   flow.set('done');
-  log(outcome.succeeded ? 'Withdraw finalized (success).' : 'Withdraw settled (refunded).');
+  log(
+    outcome.succeeded
+      ? 'Withdraw finalized (success).'
+      : 'Withdraw settled (refunded).',
+  );
 }
 
 async function evmNonce(env: Env, address: string): Promise<bigint> {
-  return BigInt(await new JsonRpcProvider(env.evmRpcUrl).getTransactionCount(address));
+  return BigInt(
+    await new JsonRpcProvider(env.evmRpcUrl).getTransactionCount(address),
+  );
 }
 
 // Ensure the vault account has approved the router for `erc20Hex`: read the live allowance,
@@ -500,15 +632,34 @@ async function ensureRouterApproved(
   const before = await readVaultLedger(providers, env);
   if (!before.initialized) throw new Error('vault not initialized');
   const rid = predictCallRequestId(
-    env, before, VAULT_PATH, nonce, erc20, MPC_ROUTING, GAS_LIMIT, MAX_FEE, PRIORITY_FEE,
+    env,
+    before,
+    VAULT_PATH,
+    nonce,
+    erc20,
+    MPC_ROUTING,
+    GAS_LIMIT,
+    MAX_FEE,
+    PRIORITY_FEE,
     APPROVE_SELECTOR,
-    [evmAddressAbiWord(addrBytes(UNISWAP_SWAP_ROUTER_02)), numericAbiWord(MAX_APPROVE)],
+    [
+      evmAddressAbiWord(addrBytes(UNISWAP_SWAP_ROUTER_02)),
+      numericAbiWord(MAX_APPROVE),
+    ],
   );
   await vault.callTx.approveRouter(erc20, nonce, SIGNET_DEFAULT_KEY_VERSION);
   await assertRequestOnLedger(providers, env, rid, 'approveRouter');
 
   // Sign-only: the vault account signs the approve, the client broadcasts it, done.
-  const signed = await pollSignatureResponse(providers, env, rid, vaultEvm, log, VAULT_REQUESTS_INDEX_FIELD, 3 * MINUTE);
+  const signed = await pollSignatureResponse(
+    providers,
+    env,
+    rid,
+    vaultEvm,
+    log,
+    VAULT_REQUESTS_INDEX_FIELD,
+    3 * MINUTE,
+  );
   await broadcastEvm(env, signed);
   log('Router approved.');
 }
@@ -524,7 +675,7 @@ export async function runSwap(
   identity: Identity,
   tokenInHex: string,
   tokenOutHex: string,
-  amount: bigint,
+  amountOut: bigint,
   log: (m: string) => void,
   fee = 500n,
   slippageBps = 100n,
@@ -538,62 +689,98 @@ export async function runSwap(
   flow.set('preparing');
   await ensureRouterApproved(providers, vault, env, tokenInHex, log);
 
-  // 2. Live QuoterV2 quote at the chosen fee tier -> amountOutMin, the on-chain slippage floor.
-  const { amountOut: quoted, amountOutMin } = await quoteExactInputSingle(
-    env.evmRpcUrl, tokenInHex, tokenOutHex, fee, amount, slippageBps,
+  // 2. Live QuoterV2 quote at the chosen fee tier -> amountInMaximum, the on-chain slippage cap.
+  const { amountIn: quoted, amountInMaximum } = await quoteExactOutputSingle(
+    env.evmRpcUrl,
+    tokenInHex,
+    tokenOutHex,
+    fee,
+    amountOut,
+    slippageBps,
   );
-  log(`Quote: ${amount} in -> ~${quoted} out (min ${amountOutMin}, fee ${fee})`);
+  log(
+    `Quote: ~${quoted} in -> ${amountOut} out (max ${amountInMaximum}, fee ${fee})`,
+  );
 
-  // 3. swap(): surrender (burn) the tokenIn vault coin, record the exactInputSingle request.
+  // 3. swap(): surrender (burn) amountInMaximum of the tokenIn vault coin, record the
+  // exactOutputSingle request. completeSwap returns the unspent remainder as change.
   const nonce = await evmNonce(env, vaultEvm);
   const before = await readVaultLedger(providers, env);
   if (!before.initialized) throw new Error('vault not initialized');
   const rid = predictCallRequestId(
-    env, before, VAULT_PATH, nonce, addrBytes(UNISWAP_SWAP_ROUTER_02),
-    SWAP_MPC_ROUTING, SWAP_GAS_LIMIT, SWAP_MAX_FEE_PER_GAS, SWAP_MAX_PRIORITY_FEE_PER_GAS,
-    EXACT_INPUT_SINGLE_SELECTOR,
+    env,
+    before,
+    VAULT_PATH,
+    nonce,
+    addrBytes(UNISWAP_SWAP_ROUTER_02),
+    SWAP_MPC_ROUTING,
+    SWAP_GAS_LIMIT,
+    SWAP_MAX_FEE_PER_GAS,
+    SWAP_MAX_PRIORITY_FEE_PER_GAS,
+    EXACT_OUTPUT_SINGLE_SELECTOR,
     [
       evmAddressAbiWord(tokenIn),
       evmAddressAbiWord(tokenOut),
       numericAbiWord(fee),
       evmAddressAbiWord(addrBytes(vaultEvm)),
-      numericAbiWord(amount),
-      numericAbiWord(amountOutMin),
+      numericAbiWord(amountOut),
+      numericAbiWord(amountInMaximum),
       numericAbiWord(0n),
     ],
   );
   const coin = {
     nonce: rand32(),
     color: hexToBytes(vaultTokenType(tokenInHex, env.contractAddress)),
-    value: amount,
+    value: amountInMaximum,
   };
 
   flow.set('proving');
   log('Submitting swap() (surrendering the tokenIn vault coin)...');
   await vault.callTx.swap(
-    nonce, SIGNET_DEFAULT_KEY_VERSION,
-    { tokenIn, tokenOut, fee, amountIn: amount, amountOutMin },
+    nonce,
+    SIGNET_DEFAULT_KEY_VERSION,
+    { tokenIn, tokenOut, fee, amountOut, amountInMaximum },
     coin,
   );
   await assertSwapRequestOnLedger(providers, env, rid);
 
-  // 4. MPC signs the swap with the vault account, broadcasts, attests (field 11 + swap schema).
+  // 4. MPC signs the swap with the vault account, broadcasts, attests (field 11 + swap schemas:
+  // decode the uint256 amountIn, verify against the uint64-packed respond output).
   const outcome = await settleViaMpc(
-    providers, env, rid, vaultEvm, log, VAULT_SWAP_REQUESTS_INDEX_FIELD, SWAP_RESULT_SCHEMA,
+    providers,
+    env,
+    rid,
+    vaultEvm,
+    log,
+    VAULT_SWAP_REQUESTS_INDEX_FIELD,
+    SWAP_OUTPUT_SCHEMA,
+    SWAP_RESPOND_SCHEMA,
   );
 
-  // 5. Settle: completeSwap mints the attested amountOut of tokenOut, or refund re-mints
-  // tokenIn if the EVM swap never executed.
+  // 5. Settle: completeSwap mints the exact amountOut of tokenOut plus the unspent tokenIn as
+  // change, or refund re-mints amountInMaximum if the EVM swap never executed.
   flow.set('claim-proving');
   if (outcome.matchedFailureOutput) {
     log('Swap did not execute on EVM — refunding tokenIn...');
-    await vault.callTx.refund(requestIdBytes(rid), outcome.event, outcome.serializedOutput, rand32());
+    await vault.callTx.refund(
+      requestIdBytes(rid),
+      outcome.event,
+      outcome.serializedOutput,
+      rand32(),
+    );
     flow.set('done');
     log('Swap refunded (did not execute).');
     return;
   }
-  log('Settling completeSwap (minting shielded tokenOut)...');
-  await vault.callTx.completeSwap(requestIdBytes(rid), outcome.event, outcome.serializedOutput, rand32());
+  log('Settling completeSwap (minting shielded tokenOut + change)...');
+  await vault.callTx.completeSwap(
+    requestIdBytes(rid),
+    outcome.event,
+    outcome.serializedOutput,
+    rand32(),
+  );
   flow.set('done');
-  log(`Swap complete — minted ${outcome.decoded?.amountOut ?? '?'} tokenOut.`);
+  log(
+    `Swap complete — minted ${amountOut} tokenOut (spent ~${outcome.decoded?.amountIn ?? '?'} tokenIn).`,
+  );
 }

--- a/frontend/lib/midnight/vault.ts
+++ b/frontend/lib/midnight/vault.ts
@@ -16,10 +16,11 @@ import {
   bytesToHex,
   stripHexPrefix,
   toSignBidirectionalEventIndex,
-  calculateSignetAttestationDigest,
+  deriveMidnightResponseKey,
   deserializeEvmOutput,
   serializeRespondOutput,
   signBidirectionalEventToSignedEvmTransaction,
+  signetEventSourceFromPublicDataProvider,
   SignetRequestResponseReader,
   SIGNET_DEFAULT_KEY_VERSION,
   PATH_BYTES,
@@ -55,7 +56,7 @@ import {
   SWAP_OUTPUT_SCHEMA,
   SWAP_RESPOND_SCHEMA,
   UNISWAP_SWAP_ROUTER_02,
-  quoteExactOutputSingle,
+  quoteExactInputSingle,
   routerAllowance,
 } from './evm-swap';
 
@@ -154,9 +155,14 @@ function responseReader(
 ): SignetRequestResponseReader {
   return new SignetRequestResponseReader({
     requesterContractAddress: env.contractAddress,
-    requesterRequestsIndexField: indexField,
+    // 0.19: the reader locates the request by ledger-tree PATH, not a field index.
+    // deposit/withdraw live at field 0 (path [0]), swaps at field 11 (path [11]).
+    requesterRequestsPath: [indexField],
     signetContractAddress: env.signetContractAddress,
     publicDataProvider: providers.publicDataProvider,
+    // 0.19: the MPC's responses are read from the signet contract's emitted
+    // events, adapted from the same public data provider.
+    eventSource: signetEventSourceFromPublicDataProvider(providers.publicDataProvider),
   } as any);
 }
 
@@ -329,30 +335,56 @@ async function pollSignatureResponse(
   throw new Error(`timed out waiting for signature response to ${requestId}`);
 }
 
-// Broadcast the MPC-signed EVM tx (idempotent across retries).
-async function broadcastEvm(env: Env, tx: Transaction): Promise<void> {
+// Broadcast the MPC-signed EVM tx (idempotent across retries). In a settle flow a revert is a
+// valid outcome — the MPC attests the failure and the caller refunds (swap/withdraw) or surfaces
+// it (deposit) — so `throwOnRevert` is false there. Sign-only flows (router approval) have no
+// attestation to fall back on, so a revert there is fatal.
+//
+// The signed tx is deterministic, so broadcasting is idempotent and retryable. A settle flow has
+// already BURNED the surrendered coin, so a failed broadcast must not strand it: there is no
+// failure attestation for a tx that never reached the chain (the MPC waits on-chain), so the only
+// recovery is to land THIS tx. `ensureGas` re-runs the gas top-up between attempts, so an
+// under-funded account ("insufficient funds") is refilled and the same signed tx re-broadcast.
+async function broadcastEvm(
+  env: Env,
+  tx: Transaction,
+  opts: { throwOnRevert?: boolean; ensureGas?: () => Promise<void> } = {},
+): Promise<void> {
+  const { throwOnRevert = true, ensureGas } = opts;
   const provider = new JsonRpcProvider(env.evmRpcUrl);
   const { hash } = tx;
   if (!hash) throw new Error('signed tx missing hash');
   const mined = await provider.getTransactionReceipt(hash);
   if (mined) {
-    if (mined.status === 0) throw new Error(`sweep ${hash} reverted`);
+    if (mined.status === 0 && throwOnRevert)
+      throw new Error(`sweep ${hash} reverted`);
     return;
   }
-  try {
-    await provider.broadcastTransaction(tx.serialized);
-  } catch (e: any) {
-    const msg = String(e?.message ?? '').toLowerCase();
-    if (
-      e?.code !== 'NONCE_EXPIRED' &&
-      !msg.includes('already known') &&
-      !msg.includes('nonce too low')
-    )
-      throw e;
+  const MAX_ATTEMPTS = 5;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await provider.broadcastTransaction(tx.serialized);
+      break;
+    } catch (e: any) {
+      const msg = String(e?.message ?? '').toLowerCase();
+      // Already in the mempool (or mined by a prior attempt) — proceed to await the receipt.
+      if (
+        e?.code === 'NONCE_EXPIRED' ||
+        msg.includes('already known') ||
+        msg.includes('nonce too low')
+      )
+        break;
+      if (attempt >= MAX_ATTEMPTS) throw e;
+      // Under-funded gas: refill and re-broadcast the same signed tx. Other transient RPC
+      // failures: back off and retry.
+      if (msg.includes('insufficient funds') && ensureGas) await ensureGas();
+      await sleep(2000);
+    }
   }
   const receipt = await provider.waitForTransaction(hash, 1, 3 * MINUTE);
   if (!receipt) throw new Error(`sweep ${hash} not confirmed`);
-  if (receipt.status === 0) throw new Error(`sweep ${hash} reverted`);
+  if (receipt.status === 0 && throwOnRevert)
+    throw new Error(`sweep ${hash} reverted`);
 }
 
 // Stage 2: match the MPC's attestation digest against the recomputed serialized output.
@@ -365,24 +397,27 @@ async function fetchAttestedRespondOutcome(
   schema: string = RESULT_SCHEMA,
   respondSchema: string = schema,
 ): Promise<any | undefined> {
-  const events = await responseReader(
-    providers,
-    env,
-    indexField,
-  ).getRespondBidirectionalEvents(requestId);
-  if (events.length === 0) return undefined;
+  const reader = responseReader(providers, env, indexField);
+  // The MPC response key the vault pinned at deploy (sender-scoped: derived from
+  // the MPC root pubkey + this vault's address). getVerifiedRespondBidirectionalEvent
+  // authenticates each candidate's signature against it — the 0.19 event carries only
+  // the signature, not a digest, so matching is by verifying, not by comparing digests.
+  const mpcResponseKey = deriveMidnightResponseKey(
+    env.mpcSecpPub,
+    env.contractAddress,
+  );
   let cached: any;
   try {
     cached = await fetchFakenetResponse(env, requestId);
   } catch {
-    return undefined;
+    cached = undefined;
   }
   const candidates: { serializedOutput: Uint8Array; isFailure: boolean }[] = [];
   // The transfer schema decodes a bool; the swap OUTPUT schema a uint256 amountIn. The MPC
   // re-packs against `respondSchema` (equal to `schema` for the symmetric transfer case, but a
   // narrower uint64 for swap). decodedValue is what a success settle reads (the bool, or amountIn).
   let decodedValue: any;
-  if (cached.success && cached.output != null) {
+  if (cached?.success && cached.output != null) {
     try {
       const decoded: any = deserializeEvmOutput(schema as any, cached.output);
       decodedValue = decoded;
@@ -395,13 +430,14 @@ async function fetchAttestedRespondOutcome(
     }
   }
   candidates.push({ serializedOutput: MPC_FAILURE_OUTPUT, isFailure: true });
+  // Only the candidate the MPC actually attested has a signature that verifies, so the
+  // first verifying candidate is the genuine outcome. An undefined return means the post
+  // is not up yet (or attests neither candidate) — the caller polls again.
   for (const c of candidates) {
-    const digest = calculateSignetAttestationDigest(
-      requestIdBytes(requestId),
+    const event = await reader.getVerifiedRespondBidirectionalEvent(
+      requestId,
       c.serializedOutput,
-    );
-    const event = (events as any[]).find(e =>
-      Buffer.from(e.attestationDigest).equals(Buffer.from(digest)),
+      mpcResponseKey,
     );
     if (event) {
       return {
@@ -430,6 +466,7 @@ async function settleViaMpc(
   indexField: number = VAULT_REQUESTS_INDEX_FIELD,
   schema: string = RESULT_SCHEMA,
   respondSchema: string = schema,
+  ensureGas?: () => Promise<void>,
 ): Promise<any> {
   flow.set('settling');
   log('Waiting for MPC signature + settling on Sepolia...');
@@ -441,7 +478,11 @@ async function settleViaMpc(
     log,
     indexField,
   );
-  await broadcastEvm(env, signed);
+  // A revert is not fatal here: the MPC attests the failed execution and the caller refunds
+  // (swap/withdraw) or reports it (deposit). Let it settle, then read the attestation below.
+  // ensureGas re-runs the top-up between broadcast retries so an under-funded account never
+  // strands the already-burned coin (there is no failure attestation for a never-sent tx).
+  await broadcastEvm(env, signed, { throwOnRevert: false, ensureGas });
   const end = Date.now() + 6 * MINUTE;
   while (Date.now() < end) {
     const outcome = await fetchAttestedRespondOutcome(
@@ -452,7 +493,7 @@ async function settleViaMpc(
       schema,
       respondSchema,
     );
-    if (outcome) return outcome;
+    if (outcome) return { ...outcome, evmTxHash: signed.hash ?? undefined };
     await sleep(1000);
   }
   throw new Error(
@@ -469,6 +510,7 @@ export async function runDeposit(
   erc20Hex: string,
   amount: bigint,
   log: (m: string) => void,
+  onRecord?: (rid: RequestIdHex, evmTxHash?: string) => void,
 ) {
   flow.start('deposit');
   const erc20 = addrBytes(erc20Hex);
@@ -503,8 +545,10 @@ export async function runDeposit(
     },
   );
   await assertRequestOnLedger(providers, env, rid, 'deposit');
+  onRecord?.(rid);
 
   const outcome = await settleViaMpc(providers, env, rid, userEvm, log);
+  onRecord?.(rid, outcome.evmTxHash);
   if (!outcome.succeeded)
     throw new Error(`MPC attested deposit ${rid} as FAILED`);
 
@@ -539,6 +583,8 @@ export async function runWithdraw(
   amount: bigint,
   destHex: string,
   log: (m: string) => void,
+  ensureGas?: () => Promise<void>,
+  onRecord?: (rid: RequestIdHex, evmTxHash?: string) => void,
 ) {
   flow.start('withdraw');
   const erc20 = addrBytes(erc20Hex);
@@ -574,11 +620,23 @@ export async function runWithdraw(
     coin,
   );
   await assertRequestOnLedger(providers, env, rid, 'withdraw');
+  onRecord?.(rid);
 
-  const outcome = await settleViaMpc(providers, env, rid, vaultEvm, log);
+  const outcome = await settleViaMpc(
+    providers,
+    env,
+    rid,
+    vaultEvm,
+    log,
+    VAULT_REQUESTS_INDEX_FIELD,
+    RESULT_SCHEMA,
+    RESULT_SCHEMA,
+    ensureGas,
+  );
+  onRecord?.(rid, outcome.evmTxHash);
 
-  flow.set('claim-proving');
   if (outcome.matchedFailureOutput) {
+    flow.set('refunding');
     log('EVM transfer never executed — refunding...');
     // refundWithdraw + refundSwap are merged into one `refund` circuit; it routes on which
     // pending-marker map holds the id (refundCommitment here).
@@ -588,21 +646,20 @@ export async function runWithdraw(
       outcome.serializedOutput,
       rand32(),
     );
-  } else {
-    log('Settling completeWithdraw...');
-    await vault.callTx.completeWithdraw(
-      requestIdBytes(rid),
-      outcome.event,
-      outcome.serializedOutput,
-      rand32(),
-    );
+    flow.finishRefunded();
+    log('Withdraw settled (refunded).');
+    return;
   }
-  flow.set('done');
-  log(
-    outcome.succeeded
-      ? 'Withdraw finalized (success).'
-      : 'Withdraw settled (refunded).',
+  flow.set('claim-proving');
+  log('Settling completeWithdraw...');
+  await vault.callTx.completeWithdraw(
+    requestIdBytes(rid),
+    outcome.event,
+    outcome.serializedOutput,
+    rand32(),
   );
+  flow.set('done');
+  log('Withdraw finalized (success).');
 }
 
 async function evmNonce(env: Env, address: string): Promise<bigint> {
@@ -675,10 +732,12 @@ export async function runSwap(
   identity: Identity,
   tokenInHex: string,
   tokenOutHex: string,
-  amountOut: bigint,
+  amountInMaximum: bigint,
   log: (m: string) => void,
   fee = 500n,
   slippageBps = 100n,
+  ensureGas?: () => Promise<void>,
+  onRecord?: (rid: RequestIdHex, evmTxHash?: string) => void,
 ) {
   flow.start('swap');
   const tokenIn = addrBytes(tokenInHex);
@@ -689,17 +748,20 @@ export async function runSwap(
   flow.set('preparing');
   await ensureRouterApproved(providers, vault, env, tokenInHex, log);
 
-  // 2. Live QuoterV2 quote at the chosen fee tier -> amountInMaximum, the on-chain slippage cap.
-  const { amountIn: quoted, amountInMaximum } = await quoteExactOutputSingle(
+  // 2. Normal-swap UX, exactOutput on-chain: the user picked the SPEND (amountInMaximum). Quote
+  // exactInput to see what it buys, then target amountOut = expected * (1 - slippage) as the
+  // guaranteed receive. The swap spends up to amountInMaximum for that output and refunds change.
+  const { amountOut: expectedOut } = await quoteExactInputSingle(
     env.evmRpcUrl,
     tokenInHex,
     tokenOutHex,
     fee,
-    amountOut,
-    slippageBps,
+    amountInMaximum,
   );
+  const amountOut = (expectedOut * (10_000n - slippageBps)) / 10_000n;
+  if (amountOut <= 0n) throw new Error('swap amount too small to quote an output');
   log(
-    `Quote: ~${quoted} in -> ${amountOut} out (max ${amountInMaximum}, fee ${fee})`,
+    `Quote: ${amountInMaximum} in -> ~${expectedOut} out (min ${amountOut}, fee ${fee})`,
   );
 
   // 3. swap(): surrender (burn) amountInMaximum of the tokenIn vault coin, record the
@@ -743,6 +805,7 @@ export async function runSwap(
     coin,
   );
   await assertSwapRequestOnLedger(providers, env, rid);
+  onRecord?.(rid);
 
   // 4. MPC signs the swap with the vault account, broadcasts, attests (field 11 + swap schemas:
   // decode the uint256 amountIn, verify against the uint64-packed respond output).
@@ -755,12 +818,14 @@ export async function runSwap(
     VAULT_SWAP_REQUESTS_INDEX_FIELD,
     SWAP_OUTPUT_SCHEMA,
     SWAP_RESPOND_SCHEMA,
+    ensureGas,
   );
+  onRecord?.(rid, outcome.evmTxHash);
 
   // 5. Settle: completeSwap mints the exact amountOut of tokenOut plus the unspent tokenIn as
   // change, or refund re-mints amountInMaximum if the EVM swap never executed.
-  flow.set('claim-proving');
   if (outcome.matchedFailureOutput) {
+    flow.set('refunding');
     log('Swap did not execute on EVM — refunding tokenIn...');
     await vault.callTx.refund(
       requestIdBytes(rid),
@@ -768,10 +833,11 @@ export async function runSwap(
       outcome.serializedOutput,
       rand32(),
     );
-    flow.set('done');
+    flow.finishRefunded();
     log('Swap refunded (did not execute).');
     return;
   }
+  flow.set('claim-proving');
   log('Settling completeSwap (minting shielded tokenOut + change)...');
   await vault.callTx.completeSwap(
     requestIdBytes(rid),

--- a/frontend/lib/midnight/wallet.ts
+++ b/frontend/lib/midnight/wallet.ts
@@ -155,7 +155,7 @@ export interface WalletHandle {
 // A cached checkpoint from a chain that was reset (new genesis) resumes without error but never
 // finishes syncing, so waitForSyncedState hangs at "connecting to indexer…". Bound the cached
 // resume with this timeout so a stalled checkpoint falls through to a from-scratch resync.
-const CACHED_SYNC_TIMEOUT_MS = 45_000;
+const CACHED_SYNC_TIMEOUT_MS = 20_000;
 
 async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout>;

--- a/frontend/lib/midnight/wallet.ts
+++ b/frontend/lib/midnight/wallet.ts
@@ -149,6 +149,7 @@ export interface WalletHandle {
   identitySecret: Uint8Array;
   facade: WalletFacade;
   keys: AccountKeys;
+  recheckpoint: () => Promise<void>;
   stop: () => Promise<void>;
 }
 
@@ -240,17 +241,23 @@ export async function initializeWallet(
   }
   log('Wallet synced.');
 
-  // Checkpoint for the next load (best-effort).
-  try {
-    const [sh, un, du] = await Promise.all([
-      (facade as any).shielded.serializeState(),
-      (facade as any).unshielded.serializeState(),
-      (facade as any).dust.serializeState(),
-    ]);
-    await idbSet(cacheKey, { shielded: sh, unshielded: un, dust: du });
-  } catch {
-    /* cache is best-effort */
-  }
+  // Serialize the live facade state to the checkpoint. Runs at first sync and again after every
+  // transaction (via the handle's recheckpoint), so a restored checkpoint stays close to the chain
+  // tip: a far-behind checkpoint mis-reconciles already-spent dust and the node rejects the next
+  // transaction as DustDoubleSpend.
+  const writeCheckpoint = async () => {
+    try {
+      const [sh, un, du] = await Promise.all([
+        (facade as any).shielded.serializeState(),
+        (facade as any).unshielded.serializeState(),
+        (facade as any).dust.serializeState(),
+      ]);
+      await idbSet(cacheKey, { shielded: sh, unshielded: un, dust: du });
+    } catch {
+      /* cache is best-effort */
+    }
+  };
+  await writeCheckpoint();
 
   // state.shielded.address is an object — bech32-encode for display.
   let shieldedAddress = '';
@@ -301,6 +308,16 @@ export async function initializeWallet(
     identitySecret: await identityFromSeed(seed),
     facade,
     keys,
+    // Re-write the checkpoint after a transaction, syncing to the tip first so the stored state
+    // reflects the just-spent dust. Best-effort: a failed sync keeps the last checkpoint.
+    recheckpoint: async () => {
+      try {
+        await withTimeout(facade.waitForSyncedState(), CACHED_SYNC_TIMEOUT_MS, 'recheckpoint sync');
+      } catch {
+        /* proceed with the latest applied state */
+      }
+      await writeCheckpoint();
+    },
     stop: async () => {
       try {
         await (facade as any).stop?.();
@@ -309,6 +326,17 @@ export async function initializeWallet(
       }
     },
   };
+}
+
+// Drop the entire wallet-state checkpoint store so the next initializeWallet syncs from scratch.
+// Used to recover from a checkpoint that has drifted behind the chain (stale-dust rejections).
+export async function clearWalletCache(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase(IDB_NAME);
+    req.onsuccess = () => resolve();
+    req.onerror = () => resolve();
+    req.onblocked = () => resolve();
+  });
 }
 
 // Join the deployed vault with the identity secret as private state.

--- a/frontend/lib/midnight/wallet.ts
+++ b/frontend/lib/midnight/wallet.ts
@@ -94,13 +94,21 @@ async function idbDelete(key: string): Promise<void> {
   });
 }
 
+// Where the ZK assets (keys/zkir/compiler) are served from. Defaults to the app origin (the
+// public/ folder in local dev), but the vault provers are 100-280 MB each — over Vercel's 100 MB
+// file cap — so in production they're hosted on object storage and NEXT_PUBLIC_ZK_CONFIG_ORIGIN
+// points the fetch there. The `/signet` assets live under the same origin.
+const ZK_ORIGIN =
+  process.env.NEXT_PUBLIC_ZK_CONFIG_ORIGIN ||
+  (typeof window !== 'undefined' ? window.location.origin : '');
+
 // Compiled-contract binding: generated Contract + witnesses + zk assets at the origin.
 const vaultCompiledContract: any = (CompiledContract.withCompiledFileAssets as any)(
   (CompiledContract.withWitnesses as any)(
     (CompiledContract.make as any)('erc20-vault', Contract as any),
     witnesses,
   ),
-  typeof window !== 'undefined' ? window.location.origin : '',
+  ZK_ORIGIN,
 );
 
 // Proving spans BOTH zk roots (vault + signet) — deposit/withdraw cross-call.
@@ -109,10 +117,9 @@ function buildProviders(
   cfg: MidnightNodeConfig,
   accountId: string,
 ) {
-  const origin = typeof window !== 'undefined' ? window.location.origin : '';
   const zkOpts = { fetchFunc: fetch.bind(window) };
-  const vaultZk = new FetchZkConfigProvider<string>(origin, zkOpts);
-  const signetZk = new FetchZkConfigProvider<string>(`${origin}/signet`, zkOpts);
+  const vaultZk = new FetchZkConfigProvider<string>(ZK_ORIGIN, zkOpts);
+  const signetZk = new FetchZkConfigProvider<string>(`${ZK_ORIGIN}/signet`, zkOpts);
 
   return {
     privateStateProvider: levelPrivateStateProvider({

--- a/frontend/lib/midnight/wallet.ts
+++ b/frontend/lib/midnight/wallet.ts
@@ -152,9 +152,26 @@ export interface WalletHandle {
   stop: () => Promise<void>;
 }
 
+// A cached checkpoint from a chain that was reset (new genesis) resumes without error but never
+// finishes syncing, so waitForSyncedState hangs at "connecting to indexer…". Bound the cached
+// resume with this timeout so a stalled checkpoint falls through to a from-scratch resync.
+const CACHED_SYNC_TIMEOUT_MS = 45_000;
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
 // Build + start + sync the facade, then assemble the provider set around it. Restores
 // from the cached checkpoint when present (delta sync); falls back to a full resync if
-// the cached state is rejected. Reports sync progress via `onProgress`.
+// the cached state is rejected or a reset chain stalls it. Reports sync progress via `onProgress`.
 export async function initializeWallet(
   networkId: string,
   log: (m: string) => void,
@@ -204,10 +221,19 @@ export async function initializeWallet(
   try {
     log(cached ? 'Resuming wallet from cached state…' : 'Starting the in-app wallet (syncing to the node)…');
     facade = await startFacade(cached);
-    state = await facade.waitForSyncedState();
+    // A stale checkpoint (e.g. after a chain reset) resumes without throwing but never syncs, so
+    // bound the cached wait; a fresh start has no checkpoint to stall on and waits normally.
+    state = cached
+      ? await withTimeout(facade.waitForSyncedState(), CACHED_SYNC_TIMEOUT_MS, 'cached wallet sync')
+      : await facade.waitForSyncedState();
   } catch (e) {
     if (!cached) throw e;
-    log('Cached wallet state rejected — resyncing from scratch…');
+    log('Cached wallet state rejected or stalled — resyncing from scratch…');
+    try {
+      await (facade! as unknown as { stop?: () => Promise<void> })?.stop?.();
+    } catch {
+      /* best-effort: drop the stalled facade before resyncing */
+    }
     await idbDelete(cacheKey);
     facade = await startFacade();
     state = await facade.waitForSyncedState();

--- a/frontend/providers/midnight-context.tsx
+++ b/frontend/providers/midnight-context.tsx
@@ -11,8 +11,14 @@ import {
   type ReactNode,
 } from 'react';
 
+import { formatUnits } from 'viem';
+
 import { midnightEnv, midnightNetworkId } from '@/lib/midnight/env';
 import { MIDNIGHT_TOKENS } from '@/lib/constants/token-metadata';
+import {
+  midnightTxHistory,
+  type MidnightTxRecord,
+} from '@/lib/midnight/tx-history';
 import { ERC20_TRANSFER_GAS_LIMIT } from '@/lib/midnight/evm-envelope';
 import { SWAP_GAS_LIMIT } from '@/lib/midnight/evm-swap';
 import type { MidnightBalances } from '@/lib/midnight/vault-balances';
@@ -87,6 +93,21 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
 
   const append = (m: string) =>
     setLog(l => [...l, `${new Date().toLocaleTimeString()}  ${m}`]);
+
+  // Token symbol + decimals for the Activity records (decimals come from the synced balances,
+  // defaulting to 6 for the demo stablecoins before the first balance read).
+  const tokenMeta = (erc20: string) => {
+    const t = MIDNIGHT_TOKENS.find(
+      x => x.erc20Address.toLowerCase() === erc20.toLowerCase(),
+    );
+    const decimals = balances?.perToken?.[erc20.toLowerCase()]?.decimals ?? 6;
+    return { symbol: t?.symbol ?? 'ERC20', decimals };
+  };
+  const fmtAmount = (amount: bigint, erc20: string) => {
+    const { symbol, decimals } = tokenMeta(erc20);
+    return `${formatUnits(amount, decimals)} ${symbol}`;
+  };
+  const nowSec = () => Math.floor(Date.now() / 1000);
 
   const startWallet = () => {
     eagerWallet ??= (async () => {
@@ -182,7 +203,7 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
         }
       }, 5000);
       setConnected(true);
-      append('Connected (Developer wallet)');
+      append('Connected (Developer wallet · Midnight)');
     } catch (e) {
       eagerWallet = null;
       append(`Error: ${(e as Error).message}`);
@@ -205,20 +226,59 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
     const { runDeposit, runWithdraw } = await import('@/lib/midnight/vault');
     const { flow } = await import('@/lib/midnight/flow');
     flow.start(kind);
+    const amountStr = fmtAmount(amountUnits, erc20Address);
+    const { symbol } = tokenMeta(erc20Address);
+    // The Activity record is keyed by the request id (the deterministic on-chain id) — added when
+    // the request lands, patched with the real Sepolia tx hash once the MPC signs, so the row's
+    // explorer link is the actual EVM transfer.
+    let recordId: string | null = null;
+    const record = (
+      rid: string,
+      base: Omit<MidnightTxRecord, 'id' | 'status' | 'timestampRaw' | 'txHash'>,
+      evmTxHash?: string,
+    ) => {
+      if (recordId === rid) {
+        if (evmTxHash) midnightTxHistory.update(rid, { txHash: evmTxHash });
+        return;
+      }
+      recordId = rid;
+      midnightTxHistory.add({
+        id: rid,
+        ...base,
+        txHash: evmTxHash,
+        status: 'pending',
+        timestampRaw: nowSec(),
+      });
+    };
     try {
       if (kind === 'deposit') {
         append('Requesting gas top-up from relayer...');
         await topUpGas(depositAddress); // sweep is sent FROM the deposit address
-        await runDeposit(providers, vault, midnightEnv, identity, erc20Address, amountUnits, append);
+        await runDeposit(providers, vault, midnightEnv, identity, erc20Address, amountUnits, append, (rid, hash) =>
+          record(
+            rid,
+            { type: 'Deposit', fromSymbol: 'WALLET', fromAmount: depositAddress, toSymbol: symbol, toAmount: amountStr, counterparty: depositAddress },
+            hash,
+          ),
+        );
       } else {
         const hex = (receiver ?? '').trim().replace(/^0x/, '');
         const destHex = hex.length === 40 ? `0x${hex}` : DEAD_ADDRESS;
         append('Requesting gas top-up from relayer...');
         await topUpGas(vaultAddress); // payout is sent FROM the vault address
-        await runWithdraw(providers, vault, midnightEnv, identity, erc20Address, amountUnits, destHex, append);
+        await runWithdraw(providers, vault, midnightEnv, identity, erc20Address, amountUnits, destHex, append, () => topUpGas(vaultAddress), (rid, hash) =>
+          record(
+            rid,
+            { type: 'Withdraw', fromSymbol: symbol, fromAmount: amountStr, toSymbol: 'WALLET', toAmount: destHex, counterparty: destHex },
+            hash,
+          ),
+        );
       }
+      if (recordId)
+        midnightTxHistory.update(recordId, { status: flow.refunded ? 'refunded' : 'completed' });
       await refresh();
     } catch (e) {
+      if (recordId) midnightTxHistory.update(recordId, { status: 'failed' });
       flow.fail((e as Error).message);
       throw e;
     }
@@ -241,12 +301,37 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
     const { runSwap } = await import('@/lib/midnight/vault');
     const { flow } = await import('@/lib/midnight/flow');
     flow.start('swap');
+    let recordId: string | null = null;
+    const record = (rid: string, evmTxHash?: string) => {
+      if (recordId === rid) {
+        if (evmTxHash) midnightTxHistory.update(rid, { txHash: evmTxHash });
+        return;
+      }
+      recordId = rid;
+      midnightTxHistory.add({
+        id: rid,
+        type: 'Swap',
+        fromSymbol: tokenMeta(tokenInErc20).symbol,
+        fromAmount: fmtAmount(amountUnits, tokenInErc20),
+        toSymbol: tokenMeta(tokenOutErc20).symbol,
+        toAmount: '',
+        txHash: evmTxHash,
+        status: 'pending',
+        timestampRaw: nowSec(),
+      });
+    };
     try {
       append('Requesting gas top-up from relayer...');
       await topUpGas(vaultAddress, SWAP_GAS_LIMIT + ERC20_TRANSFER_GAS_LIMIT);
-      await runSwap(providers, vault, midnightEnv, identity, tokenInErc20, tokenOutErc20, amountUnits, append, fee, slippageBps);
+      await runSwap(providers, vault, midnightEnv, identity, tokenInErc20, tokenOutErc20, amountUnits, append, fee, slippageBps,
+        () => topUpGas(vaultAddress, SWAP_GAS_LIMIT + ERC20_TRANSFER_GAS_LIMIT),
+        (rid, hash) => record(rid, hash),
+      );
+      if (recordId)
+        midnightTxHistory.update(recordId, { status: flow.refunded ? 'refunded' : 'completed' });
       await refresh();
     } catch (e) {
+      if (recordId) midnightTxHistory.update(recordId, { status: 'failed' });
       flow.fail((e as Error).message);
       throw e;
     }
@@ -267,7 +352,8 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
         disconnect: reset,
         deposit: (erc20, amount) => runFlow('deposit', erc20, amount),
         withdraw: (erc20, amount, receiver) => runFlow('withdraw', erc20, amount, receiver),
-        swap: (tokenIn, tokenOut, amount) => runSwapFlow(tokenIn, tokenOut, amount),
+        swap: (tokenIn, tokenOut, amount, fee, slippageBps) =>
+          runSwapFlow(tokenIn, tokenOut, amount, fee, slippageBps),
         refresh,
       }}
     >

--- a/frontend/providers/midnight-context.tsx
+++ b/frontend/providers/midnight-context.tsx
@@ -61,6 +61,22 @@ const forwardLog = (m: string) => onWalletLog?.(m);
 const DEAD_ADDRESS = '0x000000000000000000000000000000000000dEaD';
 const MIDNIGHT_ERC20S = MIDNIGHT_TOKENS.map(t => t.erc20Address);
 
+// Node rejection codes that mean the wallet's local view is behind the chain: 196 DustDoubleSpend,
+// 195 InputNotInUtxos, 171 OutOfDustValidityWindow. They surface as `Custom error: <code>` deep in
+// the submission error's cause chain. Recovery is a full resync, not a code fix.
+const STALE_STATE_ERROR_CODES = ['196', '195', '171'];
+function isStaleStateError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let cur: any = error;
+  while (cur && !seen.has(cur)) {
+    seen.add(cur);
+    const msg = String(cur.message ?? cur);
+    if (STALE_STATE_ERROR_CODES.some(code => msg.includes(`Custom error: ${code}`))) return true;
+    cur = cur.cause;
+  }
+  return false;
+}
+
 // Relayer funds the gas of the address sending the MPC-signed transfer (parity with the
 // Solana bridge's top-up), so the user never hand-funds ETH.
 async function topUpGas(fromAddress: string, gasLimit?: bigint): Promise<void> {
@@ -163,28 +179,61 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
     setBalances(null);
   };
 
+  // Wire a freshly-synced wallet handle into the refs: providers, persisted identity private
+  // state, derived identity, and the joined vault contract. Shared by connect and rebuildWallet.
+  const bindWallet = async (handle: any) => {
+    const { joinVault, VAULT_PRIVATE_STATE_ID } = await import('@/lib/midnight/wallet');
+    const { deriveIdentity } = await import('@/lib/midnight/vault');
+    providersRef.current = handle.providers;
+    walletRef.current = handle;
+    await handle.providers.privateStateProvider.setContractAddress(midnightEnv.contractAddress);
+    await handle.providers.privateStateProvider.set(VAULT_PRIVATE_STATE_ID, {
+      secretKey: handle.identitySecret,
+    });
+    const identity = deriveIdentity(handle.identitySecret);
+    identityRef.current = identity;
+    vaultRef.current = await joinVault(handle.providers, midnightEnv.contractAddress, handle.identitySecret);
+    return identity;
+  };
+
+  // Recover from a stale-state rejection: tear down the wallet, drop the drifted checkpoint, and
+  // full-resync a fresh handle bound to the same refs.
+  const rebuildWallet = async () => {
+    append('Wallet state drifted behind the chain — resyncing from scratch...');
+    try {
+      walletRef.current?.stop?.();
+    } catch {
+      /* ignore */
+    }
+    eagerWallet = null;
+    const { clearWalletCache } = await import('@/lib/midnight/wallet');
+    await clearWalletCache();
+    const handle = await startWallet();
+    await bindWallet(handle);
+  };
+
+  // Run a transaction flow; on a stale-state rejection, resync the wallet and retry it once. The
+  // op reads the refs at call time so the retry runs against the rebuilt wallet.
+  const withStaleStateRecovery = async <T,>(op: () => Promise<T>): Promise<T> => {
+    try {
+      return await op();
+    } catch (e) {
+      if (!isStaleStateError(e)) throw e;
+      await rebuildWallet();
+      return await op();
+    }
+  };
+
   const connect = async () => {
     if (connecting || connected) return;
     setConnecting(true);
     try {
-      const { joinVault, VAULT_PRIVATE_STATE_ID } = await import('@/lib/midnight/wallet');
-      const { deriveIdentity, depositAddress: depAddr, vaultAddress: vAddr } =
+      const { depositAddress: depAddr, vaultAddress: vAddr } =
         await import('@/lib/midnight/vault');
 
       const handle = await startWallet();
-      providersRef.current = handle.providers;
-      walletRef.current = handle;
       setShieldedAddress(handle.shielded.shieldedAddress);
-
-      // Persist the deterministic identity so joinVault uses it.
-      await handle.providers.privateStateProvider.setContractAddress(midnightEnv.contractAddress);
-      await handle.providers.privateStateProvider.set(VAULT_PRIVATE_STATE_ID, {
-        secretKey: handle.identitySecret,
-      });
-
-      const identity = deriveIdentity(handle.identitySecret);
-      identityRef.current = identity;
-      vaultRef.current = await joinVault(handle.providers, midnightEnv.contractAddress, handle.identitySecret);
+      const identity = await bindWallet(handle);
 
       const dAddr = depAddr(midnightEnv, identity);
       const vaddr = vAddr(midnightEnv);
@@ -254,11 +303,13 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
       if (kind === 'deposit') {
         append('Requesting gas top-up from relayer...');
         await topUpGas(depositAddress); // sweep is sent FROM the deposit address
-        await runDeposit(providers, vault, midnightEnv, identity, erc20Address, amountUnits, append, (rid, hash) =>
-          record(
-            rid,
-            { type: 'Deposit', fromSymbol: 'WALLET', fromAmount: depositAddress, toSymbol: symbol, toAmount: amountStr, counterparty: depositAddress },
-            hash,
+        await withStaleStateRecovery(() =>
+          runDeposit(providersRef.current, vaultRef.current, midnightEnv, identityRef.current, erc20Address, amountUnits, append, (rid, hash) =>
+            record(
+              rid,
+              { type: 'Deposit', fromSymbol: 'WALLET', fromAmount: depositAddress, toSymbol: symbol, toAmount: amountStr, counterparty: depositAddress },
+              hash,
+            ),
           ),
         );
       } else {
@@ -266,17 +317,20 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
         const destHex = hex.length === 40 ? `0x${hex}` : DEAD_ADDRESS;
         append('Requesting gas top-up from relayer...');
         await topUpGas(vaultAddress); // payout is sent FROM the vault address
-        await runWithdraw(providers, vault, midnightEnv, identity, erc20Address, amountUnits, destHex, append, () => topUpGas(vaultAddress), (rid, hash) =>
-          record(
-            rid,
-            { type: 'Withdraw', fromSymbol: symbol, fromAmount: amountStr, toSymbol: 'WALLET', toAmount: destHex, counterparty: destHex },
-            hash,
+        await withStaleStateRecovery(() =>
+          runWithdraw(providersRef.current, vaultRef.current, midnightEnv, identityRef.current, erc20Address, amountUnits, destHex, append, () => topUpGas(vaultAddress), (rid, hash) =>
+            record(
+              rid,
+              { type: 'Withdraw', fromSymbol: symbol, fromAmount: amountStr, toSymbol: 'WALLET', toAmount: destHex, counterparty: destHex },
+              hash,
+            ),
           ),
         );
       }
       if (recordId)
         midnightTxHistory.update(recordId, { status: flow.refunded ? 'refunded' : 'completed' });
       await refresh();
+      await walletRef.current?.recheckpoint?.();
     } catch (e) {
       if (recordId) midnightTxHistory.update(recordId, { status: 'failed' });
       flow.fail((e as Error).message);
@@ -323,13 +377,16 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
     try {
       append('Requesting gas top-up from relayer...');
       await topUpGas(vaultAddress, SWAP_GAS_LIMIT + ERC20_TRANSFER_GAS_LIMIT);
-      await runSwap(providers, vault, midnightEnv, identity, tokenInErc20, tokenOutErc20, amountUnits, append, fee, slippageBps,
-        () => topUpGas(vaultAddress, SWAP_GAS_LIMIT + ERC20_TRANSFER_GAS_LIMIT),
-        (rid, hash) => record(rid, hash),
+      await withStaleStateRecovery(() =>
+        runSwap(providersRef.current, vaultRef.current, midnightEnv, identityRef.current, tokenInErc20, tokenOutErc20, amountUnits, append, fee, slippageBps,
+          () => topUpGas(vaultAddress, SWAP_GAS_LIMIT + ERC20_TRANSFER_GAS_LIMIT),
+          (rid, hash) => record(rid, hash),
+        ),
       );
       if (recordId)
         midnightTxHistory.update(recordId, { status: flow.refunded ? 'refunded' : 'completed' });
       await refresh();
+      await walletRef.current?.recheckpoint?.();
     } catch (e) {
       if (recordId) midnightTxHistory.update(recordId, { status: 'failed' });
       flow.fail((e as Error).message);

--- a/frontend/providers/midnight-context.tsx
+++ b/frontend/providers/midnight-context.tsx
@@ -13,6 +13,8 @@ import {
 
 import { midnightEnv, midnightNetworkId } from '@/lib/midnight/env';
 import { MIDNIGHT_TOKENS } from '@/lib/constants/token-metadata';
+import { ERC20_TRANSFER_GAS_LIMIT } from '@/lib/midnight/evm-envelope';
+import { SWAP_GAS_LIMIT } from '@/lib/midnight/evm-swap';
 import type { MidnightBalances } from '@/lib/midnight/vault-balances';
 
 export type { MidnightBalances, MidnightTokenBalance } from '@/lib/midnight/vault-balances';
@@ -30,6 +32,7 @@ interface MidnightContextValue {
   disconnect: () => void;
   deposit: (erc20Address: string, amountUnits: bigint) => Promise<void>;
   withdraw: (erc20Address: string, amountUnits: bigint, receiver?: string) => Promise<void>;
+  swap: (tokenInErc20: string, tokenOutErc20: string, amountUnits: bigint, fee?: bigint, slippageBps?: bigint) => Promise<void>;
   refresh: () => Promise<void>;
 }
 
@@ -54,11 +57,11 @@ const MIDNIGHT_ERC20S = MIDNIGHT_TOKENS.map(t => t.erc20Address);
 
 // Relayer funds the gas of the address sending the MPC-signed transfer (parity with the
 // Solana bridge's top-up), so the user never hand-funds ETH.
-async function topUpGas(fromAddress: string): Promise<void> {
+async function topUpGas(fromAddress: string, gasLimit?: bigint): Promise<void> {
   const res = await fetch('/api/midnight/gas-topup', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ fromAddress }),
+    body: JSON.stringify({ fromAddress, gasLimit: gasLimit?.toString() }),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
@@ -221,6 +224,34 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  // Swap has two tokens (in/out), so it doesn't fit runFlow's single-erc20 signature. The
+  // swap is signed + paid by the VAULT account (it holds the pooled funds), so top up the
+  // vault for the swap's larger gas envelope PLUS a possible one-time router approval.
+  const runSwapFlow = async (
+    tokenInErc20: string,
+    tokenOutErc20: string,
+    amountUnits: bigint,
+    fee = 500n,
+    slippageBps = 100n,
+  ) => {
+    const providers = providersRef.current;
+    const vault = vaultRef.current;
+    const identity = identityRef.current;
+    if (!providers || !vault || !identity) throw new Error('Connect the Midnight wallet first.');
+    const { runSwap } = await import('@/lib/midnight/vault');
+    const { flow } = await import('@/lib/midnight/flow');
+    flow.start('swap');
+    try {
+      append('Requesting gas top-up from relayer...');
+      await topUpGas(vaultAddress, SWAP_GAS_LIMIT + ERC20_TRANSFER_GAS_LIMIT);
+      await runSwap(providers, vault, midnightEnv, identity, tokenInErc20, tokenOutErc20, amountUnits, append, fee, slippageBps);
+      await refresh();
+    } catch (e) {
+      flow.fail((e as Error).message);
+      throw e;
+    }
+  };
+
   return (
     <MidnightContext.Provider
       value={{
@@ -236,6 +267,7 @@ export function MidnightProvider({ children }: { children: ReactNode }) {
         disconnect: reset,
         deposit: (erc20, amount) => runFlow('deposit', erc20, amount),
         withdraw: (erc20, amount, receiver) => runFlow('withdraw', erc20, amount, receiver),
+        swap: (tokenIn, tokenOut, amount) => runSwapFlow(tokenIn, tokenOut, amount),
         refresh,
       }}
     >


### PR DESCRIPTION
Adds a Midnight-only swap widget on top of #45 (deposit/withdraw).

- `evm-swap.ts`: QuoterV2 quote, best-fee-tier discovery, pool discovery via the V3 factory, `runSwap` round trip.
- SwapWidget: only offers token pairs that have a pool, auto-detects the fee tier, and a settings modal for slippage.
- Threads fee + slippage through the context `swap()`.

Stacked on `midnight-vault`; merge #45 first.
